### PR TITLE
Add file info and index decoders to the lzma-safe library

### DIFF
--- a/lzma-safe/src/decoder/file_info.rs
+++ b/lzma-safe/src/decoder/file_info.rs
@@ -1,0 +1,449 @@
+//! High-level, safe Rust wrapper for liblzma's file info decoder.
+
+use crate::stream::LzmaAllocator;
+use crate::{Action, Error, Index, Result, Stream};
+
+/// Safe wrapper around liblzma's file info decoder.
+///
+/// This decoder extracts index metadata from a complete XZ file by reading
+/// Stream Headers, Stream Footers, Index blocks, and Stream Padding.
+/// It can seek within the file to efficiently extract metadata without
+/// decompressing the actual data.
+pub struct FileInfoDecoder {
+    /// The underlying stream
+    stream: Option<Stream>,
+    /// Boxed pointer to ensure stable address for liblzma to write to
+    index_ptr_box: Box<*mut liblzma_sys::lzma_index>,
+    /// The extracted index (available only after decoding completes)
+    index: Option<Index>,
+    /// Size of the input file (required by liblzma)
+    file_size: u64,
+    /// Allocator from the stream, kept for cleanup
+    allocator: Option<LzmaAllocator>,
+}
+
+impl FileInfoDecoder {
+    /// Create a new file info decoder.
+    ///
+    /// # Parameters
+    ///
+    /// * `memlimit` - Maximum memory usage for the decoder
+    /// * `file_size` - Total size of the input XZ file in bytes
+    /// * `stream` - The underlying stream
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::MemError`] if memory allocation fails.
+    /// Returns [`Error::ProgError`] if the decoder is misused.
+    pub fn new(memlimit: u64, file_size: u64, mut stream: Stream) -> Result<Self> {
+        let mut index_ptr_box = Box::new(std::ptr::null_mut());
+        let allocator = stream.allocator();
+        crate::ffi::lzma_file_info_decoder(&mut stream, &mut *index_ptr_box, memlimit, file_size)?;
+        Ok(Self {
+            stream: Some(stream),
+            index_ptr_box,
+            index: None,
+            file_size,
+            allocator,
+        })
+    }
+
+    /// Process input data and extract file information.
+    ///
+    /// # Parameters
+    ///
+    /// * `input` - Input data buffer
+    /// * `action` - Action to perform (Run or Finish)
+    ///
+    /// # Returns
+    ///
+    /// Returns the number of bytes consumed from input.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::SeekNeeded`] if the decoder needs the application to seek
+    /// to a different position in the file. Use [`seek_pos()`](Self::seek_pos) to get the target position.
+    /// Returns various other errors depending on the input data and decoder state.
+    pub fn process(&mut self, input: &[u8], action: Action) -> Result<usize> {
+        // Take ownership of the stream for this operation.
+        let Some(mut stream) = self.stream.take() else {
+            // Stream is already finished or dropped; this is a logic error.
+            return Err(crate::Error::ProgError);
+        };
+
+        if !input.is_empty() {
+            stream.set_next_input(input);
+        }
+
+        let input_before = stream.avail_in();
+
+        // Call lzma_code with proper mutable reference
+        let result = crate::ffi::lzma_code(&mut stream, action);
+        let bytes_read = input_before - stream.avail_in();
+
+        // Handle special case for Action::Finish with empty input where liblzma
+        // may require an additional call to signal LZMA_STREAM_END properly.
+        let result =
+            if action == Action::Finish && result.is_ok() && input_before == 0 && bytes_read == 0 {
+                // For empty inputs liblzma may require one additional call before
+                // signalling `LZMA_STREAM_END`. Invoke it here so callers don't
+                // need to loop in trivial cases.
+                let second_result = crate::ffi::lzma_code(&mut stream, action);
+                let second_bytes_read = input_before - stream.avail_in();
+
+                if (second_result.is_ok() || matches!(second_result, Err(crate::Error::BufError)))
+                    && second_bytes_read == 0
+                {
+                    // Force stream end when no progress is made on the second call
+                    Err(crate::Error::StreamEnd)
+                } else {
+                    second_result
+                }
+            } else {
+                result
+            };
+
+        match result {
+            Ok(()) => {
+                // Decoding continues; put the stream back for further use.
+                self.stream = Some(stream);
+                Ok(bytes_read)
+            }
+            Err(Error::SeekNeeded) => {
+                // Decoder needs seeking; put the stream back and return the error.
+                self.stream = Some(stream);
+                Err(Error::SeekNeeded)
+            }
+            Err(crate::Error::StreamEnd) => {
+                // Decoding is finished; extract the index if it's valid.
+                if !(*self.index_ptr_box).is_null() {
+                    // SAFETY: index_ptr is valid and was populated by liblzma
+                    // Pass the stream's allocator to the index
+                    let allocator = stream.allocator();
+                    self.index = unsafe { Index::from_raw(*self.index_ptr_box, allocator) };
+                    // Clear the pointer since we've taken ownership
+                    *self.index_ptr_box = std::ptr::null_mut();
+                }
+                stream.finish();
+                Ok(bytes_read)
+            }
+            Err(err) => {
+                // On error, retain the stream for possible recovery or inspection.
+                self.stream = Some(stream);
+                Err(err)
+            }
+        }
+    }
+
+    /// Get the seek position if the decoder needs to seek.
+    ///
+    /// This should be called when `process` returns [`Error::SeekNeeded`].
+    /// The application should then seek to this position in the input file
+    /// and provide data starting from this position.
+    pub fn seek_pos(&self) -> u64 {
+        self.stream.as_ref().map_or(0, |s| s.seek_pos())
+    }
+
+    /// Returns whether the decoding has finished and the index is available.
+    pub fn is_finished(&self) -> bool {
+        self.stream.is_none()
+    }
+
+    /// Get the total number of input bytes processed.
+    pub fn total_in(&self) -> u64 {
+        self.stream.as_ref().map_or(0, |s| s.total_in())
+    }
+
+    /// Get the size of the input file.
+    pub fn file_size(&self) -> u64 {
+        self.file_size
+    }
+
+    /// Returns a reference to the extracted index if decoding completed successfully.
+    ///
+    /// Returns `None` if decoding has not finished yet.
+    pub fn index(&self) -> Option<&Index> {
+        if !self.is_finished() {
+            return None;
+        }
+        self.index.as_ref()
+    }
+}
+
+impl Drop for FileInfoDecoder {
+    fn drop(&mut self) {
+        // Free the index if it wasn't wrapped in Index yet
+        if !(*self.index_ptr_box).is_null() {
+            crate::ffi::lzma_index_end(*self.index_ptr_box, self.allocator.as_ref());
+        }
+
+        // Finalize the stream
+        if let Some(stream) = self.stream.take() {
+            stream.finish();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Action, Error, Stream};
+
+    /// Test FileInfoDecoder creation and basic API.
+    #[test]
+    fn file_info_decoder_creation() {
+        let decoder = Stream::default().file_info_decoder(u64::MAX, 1024).unwrap();
+
+        // Initially the decoder is not finished
+        assert!(!decoder.is_finished());
+
+        // Index should not be available before decoding
+        assert!(decoder.index().is_none());
+
+        // Total in should be zero
+        assert_eq!(decoder.total_in(), 0);
+
+        // File size should match
+        assert_eq!(decoder.file_size(), 1024);
+    }
+
+    /// Test FileInfoDecoder with invalid file data returns error.
+    #[test]
+    fn file_info_decoder_invalid_data() {
+        let invalid_data = b"Not a valid XZ file";
+
+        let mut decoder = Stream::default()
+            .file_info_decoder(u64::MAX, invalid_data.len() as u64)
+            .unwrap();
+
+        let result = decoder.process(invalid_data, Action::Finish);
+
+        // Should return an error for invalid data
+        assert!(result.is_err());
+    }
+
+    /// Test FileInfoDecoder process_after_finish returns error.
+    #[test]
+    fn file_info_decoder_process_after_finish() {
+        let invalid_data = b"test";
+
+        let mut decoder = Stream::default()
+            .file_info_decoder(u64::MAX, invalid_data.len() as u64)
+            .unwrap();
+
+        // Try to process invalid data (will likely fail or succeed with error)
+        let _ = decoder.process(invalid_data, Action::Finish);
+
+        // Even if processing failed, trying again when stream is None should give ProgError
+        if decoder.is_finished() {
+            let result = decoder.process(invalid_data, Action::Run);
+            assert!(result.is_err());
+            // Should be ProgError if stream was finished
+            if let Err(err) = result {
+                assert_eq!(err, Error::ProgError);
+            }
+        }
+    }
+
+    /// Test FileInfoDecoder seek_pos method exists and returns value.
+    #[test]
+    fn file_info_decoder_seek_pos() {
+        let decoder = Stream::default().file_info_decoder(u64::MAX, 1024).unwrap();
+
+        // Should be able to call seek_pos
+        let pos = decoder.seek_pos();
+        // Initially should be 0
+        assert_eq!(pos, 0);
+    }
+
+    /// Test FileInfoDecoder total_in counter.
+    #[test]
+    fn file_info_decoder_total_in() {
+        let mut decoder = Stream::default().file_info_decoder(u64::MAX, 1024).unwrap();
+
+        assert_eq!(decoder.total_in(), 0);
+
+        // Process some data (even if it fails)
+        let test_data = b"test data";
+        let _ = decoder.process(test_data, Action::Run);
+
+        // Total in may have changed
+        let _ = decoder.total_in();
+    }
+
+    /// Test FileInfoDecoder round-trip with Encoder.
+    ///
+    /// Creates compressed data and verifies file info decoder can process it.
+    #[test]
+    fn file_info_decoder_with_encoder_roundtrip() {
+        use crate::encoder::options::{Compression, IntegrityCheck};
+
+        // Test data to compress
+        let test_data = b"The quick brown fox jumps over the lazy dog";
+
+        // Compress data using encoder
+        let mut encoder = Stream::default()
+            .easy_encoder(Compression::Level3, IntegrityCheck::Crc64)
+            .unwrap();
+
+        let mut compressed = vec![0u8; 4096];
+        let (read, written) = encoder
+            .process(test_data, &mut compressed, Action::Run)
+            .unwrap();
+        assert_eq!(read, test_data.len());
+
+        let mut total_written = written;
+        let (_, finish_written) = encoder
+            .process(&[], &mut compressed[total_written..], Action::Finish)
+            .unwrap();
+        total_written += finish_written;
+        compressed.truncate(total_written);
+
+        assert!(encoder.is_finished());
+        assert!(!compressed.is_empty());
+
+        // Now use FileInfoDecoder to extract file information
+        let mut file_info_decoder = Stream::default()
+            .file_info_decoder(u64::MAX, compressed.len() as u64)
+            .unwrap();
+
+        let mut consumed = 0;
+        loop {
+            match file_info_decoder.process(&compressed[consumed..], Action::Run) {
+                Ok(bytes) => {
+                    consumed += bytes;
+                    if file_info_decoder.is_finished() {
+                        break;
+                    }
+                }
+                Err(Error::SeekNeeded) => {
+                    // Get seek position and adjust consumed
+                    let seek_pos = file_info_decoder.seek_pos();
+                    consumed = seek_pos as usize;
+                }
+                Err(_) => {
+                    // Error occurred, but we can still check if index was extracted
+                    break;
+                }
+            }
+
+            if consumed >= compressed.len() {
+                break;
+            }
+        }
+
+        // Try to get the index (may or may not be available depending on how decoding went)
+        let _ = file_info_decoder.index();
+    }
+
+    /// Test FileInfoDecoder with stream that has zero blocks.
+    ///
+    /// Empty XZ stream with no data blocks.
+    #[test]
+    fn file_info_decoder_with_empty_xz_stream() {
+        use crate::encoder::options::{Compression, IntegrityCheck};
+
+        // Compress empty data
+        let mut encoder = Stream::default()
+            .easy_encoder(Compression::Level1, IntegrityCheck::Crc32)
+            .unwrap();
+
+        let mut compressed = vec![0u8; 1024];
+        let (read, written) = encoder
+            .process(&[], &mut compressed, Action::Finish)
+            .unwrap();
+        assert_eq!(read, 0);
+        compressed.truncate(written);
+
+        assert!(encoder.is_finished());
+        assert!(!compressed.is_empty()); // Should have header/index/footer
+
+        // Try to decode file info from empty stream
+        let mut file_info_decoder = Stream::default()
+            .file_info_decoder(u64::MAX, compressed.len() as u64)
+            .unwrap();
+
+        let mut consumed = 0;
+        loop {
+            match file_info_decoder.process(&compressed[consumed..], Action::Run) {
+                Ok(bytes) => {
+                    consumed += bytes;
+                    if file_info_decoder.is_finished() {
+                        break;
+                    }
+                }
+                Err(Error::SeekNeeded) => {
+                    let seek_pos = file_info_decoder.seek_pos();
+                    consumed = seek_pos as usize;
+                }
+                Err(_) => break,
+            }
+
+            if consumed >= compressed.len() {
+                break;
+            }
+        }
+
+        // Index may be available
+        let _ = file_info_decoder.index();
+    }
+
+    /// Test memory limit enforcement.
+    ///
+    /// Verifies that decoder respects memory limits.
+    #[test]
+    fn file_info_decoder_memory_limit() {
+        // Create decoder with reasonable memory limit
+        let result = Stream::default().file_info_decoder(1024 * 1024, 1024);
+
+        // Should succeed to create
+        assert!(result.is_ok());
+
+        let decoder = result.unwrap();
+        assert_eq!(decoder.total_in(), 0);
+        assert!(!decoder.is_finished());
+    }
+
+    /// Test decoder state consistency.
+    ///
+    /// Verifies decoder maintains consistent state throughout processing.
+    #[test]
+    fn file_info_decoder_state_consistency() {
+        let mut decoder = Stream::default().file_info_decoder(u64::MAX, 1024).unwrap();
+
+        // Initial state
+        assert!(!decoder.is_finished());
+        assert_eq!(decoder.total_in(), 0);
+        assert_eq!(decoder.seek_pos(), 0);
+        assert!(decoder.index().is_none());
+        assert_eq!(decoder.file_size(), 1024);
+
+        // After processing invalid data
+        let test_data = b"invalid";
+        let result = decoder.process(test_data, Action::Run);
+
+        if result.is_err() {
+            // Decoder should still be in consistent state after error
+            assert!(!decoder.is_finished());
+        }
+    }
+
+    /// Test that index() returns None before finishing.
+    ///
+    /// Validates index is only available after successful decode.
+    #[test]
+    fn file_info_decoder_index_availability() {
+        let mut decoder = Stream::default().file_info_decoder(u64::MAX, 1024).unwrap();
+
+        // Before any processing
+        assert!(decoder.index().is_none());
+
+        // During processing (with invalid data)
+        let test_data = b"not an xz file";
+        let _ = decoder.process(test_data, Action::Run);
+
+        if !decoder.is_finished() {
+            // Index should not be available yet
+            assert!(decoder.index().is_none());
+        }
+    }
+}

--- a/lzma-safe/src/decoder/index.rs
+++ b/lzma-safe/src/decoder/index.rs
@@ -1,0 +1,430 @@
+//! High-level, safe Rust wrapper for liblzma's XZ Index decoder.
+
+use crate::stream::LzmaAllocator;
+use crate::{Action, Index, Result, Stream};
+
+/// Safe wrapper around liblzma's index decoder.
+///
+/// This decoder extracts index metadata from XZ Index blocks without decompressing the actual data.
+/// It can be used to get information about streams, blocks, compression ratios, etc.
+pub struct IndexDecoder {
+    /// The underlying stream
+    stream: Option<Stream>,
+    /// Pointer to the index being decoded (owned by liblzma until decoding completes)
+    index_ptr: *mut liblzma_sys::lzma_index,
+    /// The extracted index (available only after decoding completes)
+    index: Option<Index>,
+    /// Allocator from the stream, kept for cleanup
+    allocator: Option<LzmaAllocator>,
+}
+
+impl IndexDecoder {
+    /// Create a new index decoder.
+    ///
+    /// # Parameters
+    ///
+    /// * `memlimit` - Maximum memory usage for the decoder
+    /// * `stream` - The underlying stream
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::MemError`] if memory allocation fails.
+    /// Returns [`Error::ProgError`] if the decoder is misused.
+    pub fn new(memlimit: u64, mut stream: Stream) -> Result<Self> {
+        let mut index_ptr: *mut liblzma_sys::lzma_index = std::ptr::null_mut();
+        let allocator = stream.allocator();
+        crate::ffi::lzma_index_decoder(&mut stream, &mut index_ptr, memlimit)?;
+        Ok(Self {
+            stream: Some(stream),
+            index_ptr,
+            index: None,
+            allocator,
+        })
+    }
+
+    /// Process input data and extract file information.
+    ///
+    /// # Parameters
+    ///
+    /// * `input` - Input data buffer
+    /// * `action` - Action to perform (Run or Finish)
+    ///
+    /// # Returns
+    ///
+    /// Returns the number of bytes consumed from input.
+    ///
+    /// # Errors
+    ///
+    /// Returns various errors depending on the input data and decoder state.
+    pub fn process(&mut self, input: &[u8], action: Action) -> Result<usize> {
+        // Take ownership of the stream for this operation.
+        let Some(mut stream) = self.stream.take() else {
+            // Stream is already finished or dropped; this is a logic error.
+            return Err(crate::Error::ProgError);
+        };
+
+        if !input.is_empty() {
+            stream.set_next_input(input);
+        }
+
+        let input_before = stream.avail_in();
+
+        // Call lzma_code with proper mutable reference
+        let result = crate::ffi::lzma_code(&mut stream, action);
+        let bytes_read = input_before - stream.avail_in();
+
+        // Handle special case for Action::Finish with empty input where liblzma
+        // may require an additional call to signal LZMA_STREAM_END properly.
+        let result =
+            if action == Action::Finish && result.is_ok() && input_before == 0 && bytes_read == 0 {
+                // For empty inputs liblzma may require one additional call before
+                // signalling `LZMA_STREAM_END`. Invoke it here so callers don't
+                // need to loop in trivial cases.
+                let second_result = crate::ffi::lzma_code(&mut stream, action);
+                let second_bytes_read = input_before - stream.avail_in();
+
+                if (second_result.is_ok() || matches!(second_result, Err(crate::Error::BufError)))
+                    && second_bytes_read == 0
+                {
+                    // Force stream end when no progress is made on the second call
+                    Err(crate::Error::StreamEnd)
+                } else {
+                    second_result
+                }
+            } else {
+                result
+            };
+
+        match result {
+            Ok(()) => {
+                // Decoding continues; put the stream back for further use.
+                self.stream = Some(stream);
+                Ok(bytes_read)
+            }
+            Err(crate::Error::StreamEnd) => {
+                // Decoding is finished; extract the index if it's valid.
+                if !self.index_ptr.is_null() {
+                    // SAFETY: index_ptr is valid and was populated by liblzma
+                    // Pass the stream's allocator to the index
+                    let allocator = stream.allocator();
+                    self.index = unsafe { Index::from_raw(self.index_ptr, allocator) };
+                    // Clear the pointer since we've taken ownership
+                    self.index_ptr = std::ptr::null_mut();
+                }
+                stream.finish();
+                Ok(bytes_read)
+            }
+            Err(err) => {
+                // On error, retain the stream for possible recovery or inspection.
+                self.stream = Some(stream);
+                Err(err)
+            }
+        }
+    }
+
+    /// Get the seek position if the decoder needs to seek.
+    ///
+    /// This should be called when `process` returns `Action::Run` and the
+    /// decoder needs to seek to a specific position in the input file.
+    pub fn seek_pos(&mut self) -> u64 {
+        self.stream.as_mut().map_or(0, |s| s.lzma_stream().seek_pos)
+    }
+
+    /// Returns whether the decoding has finished and the index is available.
+    pub fn is_finished(&self) -> bool {
+        self.stream.is_none()
+    }
+
+    /// Get the total number of input bytes processed.
+    pub fn total_in(&self) -> u64 {
+        self.stream.as_ref().map_or(0, |s| s.total_in())
+    }
+
+    /// Returns a reference to the extracted index if decoding completed successfully.
+    ///
+    /// Returns `None` if decoding has not finished yet.
+    pub fn index(&self) -> Option<&Index> {
+        if !self.is_finished() {
+            return None;
+        }
+        self.index.as_ref()
+    }
+}
+
+impl Drop for IndexDecoder {
+    fn drop(&mut self) {
+        // Free the index if it wasn't wrapped in Index yet
+        if !self.index_ptr.is_null() {
+            crate::ffi::lzma_index_end(self.index_ptr, self.allocator.as_ref());
+        }
+
+        // Finalize the stream
+        if let Some(stream) = self.stream.take() {
+            stream.finish();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Action, Error, Stream};
+
+    /// Test IndexDecoder creation and basic API.
+    #[test]
+    fn index_decoder_creation() {
+        let decoder = Stream::default().index_decoder(u64::MAX).unwrap();
+
+        // Initially the decoder is not finished
+        assert!(!decoder.is_finished());
+
+        // Index should not be available before decoding
+        assert!(decoder.index().is_none());
+
+        // Total in should be zero
+        assert_eq!(decoder.total_in(), 0);
+    }
+
+    /// Test IndexDecoder with invalid index data returns error.
+    #[test]
+    fn index_decoder_invalid_data() {
+        let invalid_data = b"Not a valid XZ Index block";
+
+        let mut decoder = Stream::default().index_decoder(u64::MAX).unwrap();
+
+        let result = decoder.process(invalid_data, Action::Finish);
+
+        // Should return an error for invalid data
+        assert!(result.is_err());
+    }
+
+    /// Test IndexDecoder process_after_finish returns error.
+    #[test]
+    fn index_decoder_process_after_finish() {
+        let invalid_data = b"test";
+
+        let mut decoder = Stream::default().index_decoder(u64::MAX).unwrap();
+
+        // Try to process invalid data (will likely fail or succeed with error)
+        let _ = decoder.process(invalid_data, Action::Finish);
+
+        // Even if processing failed, trying again when stream is None should give ProgError
+        if decoder.is_finished() {
+            let result = decoder.process(invalid_data, Action::Run);
+            assert!(result.is_err());
+            // Should be ProgError if stream was finished
+            if let Err(err) = result {
+                assert_eq!(err, Error::ProgError);
+            }
+        }
+    }
+
+    /// Test IndexDecoder seek_pos method exists and returns value.
+    #[test]
+    fn index_decoder_seek_pos() {
+        let mut decoder = Stream::default().index_decoder(u64::MAX).unwrap();
+
+        // Should be able to call seek_pos
+        let pos = decoder.seek_pos();
+        // Initially should be 0
+        assert_eq!(pos, 0);
+    }
+
+    /// Test IndexDecoder total_in counter.
+    #[test]
+    fn index_decoder_total_in() {
+        let mut decoder = Stream::default().index_decoder(u64::MAX).unwrap();
+
+        assert_eq!(decoder.total_in(), 0);
+
+        // Process some data (even if it fails)
+        let test_data = b"test data";
+        let _ = decoder.process(test_data, Action::Run);
+
+        // Total in may have changed
+        let _ = decoder.total_in();
+    }
+
+    /// Test IndexDecoder round-trip with Encoder.
+    ///
+    /// Creates compressed data and verifies index decoder can process it.
+    #[test]
+    fn index_decoder_with_encoder_roundtrip() {
+        use crate::encoder::options::{Compression, IntegrityCheck};
+
+        // Test data to compress
+        let test_data = b"Lazzy dog jumps over the lazy fox";
+
+        // Compress data using encoder
+        let mut encoder = Stream::default()
+            .easy_encoder(Compression::Level3, IntegrityCheck::Crc64)
+            .unwrap();
+
+        let mut compressed = vec![0u8; 4096];
+        let (read, written) = encoder
+            .process(test_data, &mut compressed, Action::Run)
+            .unwrap();
+        assert_eq!(read, test_data.len());
+
+        let mut total_written = written;
+        let (_, finish_written) = encoder
+            .process(&[], &mut compressed[total_written..], Action::Finish)
+            .unwrap();
+        total_written += finish_written;
+        compressed.truncate(total_written);
+
+        assert!(encoder.is_finished());
+        assert!(!compressed.is_empty());
+
+        // Note: IndexDecoder expects only the Index section of the XZ file,
+        // not the full file. For full file parsing, use FileInfoDecoder.
+        let mut index_decoder = Stream::default().index_decoder(u64::MAX).unwrap();
+        let _result = index_decoder.process(&compressed, Action::Finish);
+
+        // The decoder may return an error since we're feeding it a full XZ file
+        // instead of just the Index section. This is expected behavior.
+    }
+
+    /// Test IndexDecoder with stream that has zero blocks.
+    ///
+    /// Empty XZ stream with no data blocks.
+    #[test]
+    fn index_decoder_with_empty_xz_stream() {
+        use crate::encoder::options::{Compression, IntegrityCheck};
+
+        // Compress empty data
+        let mut encoder = Stream::default()
+            .easy_encoder(Compression::Level1, IntegrityCheck::Crc32)
+            .unwrap();
+
+        let mut compressed = vec![0u8; 1024];
+        let (read, written) = encoder
+            .process(&[], &mut compressed, Action::Finish)
+            .unwrap();
+        assert_eq!(read, 0);
+        compressed.truncate(written);
+
+        assert!(encoder.is_finished());
+        assert!(!compressed.is_empty()); // Should have header/index/footer
+
+        // Try to decode index from empty stream
+        let mut index_decoder = Stream::default().index_decoder(u64::MAX).unwrap();
+        let _result = index_decoder.process(&compressed, Action::Finish);
+
+        // May fail since we're passing full XZ file, not just Index section
+    }
+
+    /// Test memory limit enforcement.
+    ///
+    /// Verifies that decoder respects memory limits.
+    #[test]
+    fn index_decoder_memory_limit() {
+        // Create decoder with very small memory limit
+        let result = Stream::default().index_decoder(1);
+
+        // Should succeed to create
+        assert!(result.is_ok());
+
+        let decoder = result.unwrap();
+        assert_eq!(decoder.total_in(), 0);
+        assert!(!decoder.is_finished());
+    }
+
+    /// Test seek_pos tracking.
+    ///
+    /// Verifies seek position is properly tracked.
+    #[test]
+    fn index_decoder_seek_position_tracking() {
+        let mut decoder = Stream::default().index_decoder(u64::MAX).unwrap();
+
+        let initial_pos = decoder.seek_pos();
+        assert_eq!(initial_pos, 0);
+
+        // Process some invalid data
+        let test_data = b"Not an XZ Index";
+        let _ = decoder.process(test_data, Action::Run);
+
+        // Seek pos may change if decoder needs to seek
+        let _ = decoder.seek_pos();
+    }
+
+    /// Test total_in tracking during processing.
+    ///
+    /// Verifies input byte counter is properly maintained.
+    #[test]
+    fn index_decoder_tracks_input_bytes() {
+        let mut decoder = Stream::default().index_decoder(u64::MAX).unwrap();
+        assert_eq!(decoder.total_in(), 0);
+
+        let test_data = b"test data for byte counting";
+        let _ = decoder.process(test_data, Action::Run);
+
+        // total_in should reflect bytes consumed
+        // Note: actual value depends on how much liblzma consumed
+        let _total = decoder.total_in();
+    }
+
+    /// Test decoder state consistency.
+    ///
+    /// Verifies decoder maintains consistent state throughout processing.
+    #[test]
+    fn index_decoder_state_consistency() {
+        let mut decoder = Stream::default().index_decoder(u64::MAX).unwrap();
+
+        // Initial state
+        assert!(!decoder.is_finished());
+        assert_eq!(decoder.total_in(), 0);
+        assert_eq!(decoder.seek_pos(), 0);
+        assert!(decoder.index().is_none());
+
+        // After processing invalid data
+        let test_data = b"invalid";
+        let result = decoder.process(test_data, Action::Run);
+
+        if result.is_err() {
+            // Decoder should still be in consistent state after error
+            assert!(!decoder.is_finished());
+        }
+    }
+
+    /// Test decoder with Action::Run vs Action::Finish.
+    ///
+    /// Verifies different actions behave correctly.
+    #[test]
+    fn index_decoder_action_handling() {
+        let test_data = b"test data";
+
+        // Test with Action::Run
+        {
+            let mut decoder = Stream::default().index_decoder(u64::MAX).unwrap();
+            let _result = decoder.process(test_data, Action::Run);
+            // Decoder may or may not finish depending on data
+        }
+
+        // Test with Action::Finish
+        {
+            let mut decoder = Stream::default().index_decoder(u64::MAX).unwrap();
+            let _result = decoder.process(test_data, Action::Finish);
+            // Finish should signal end of input
+        }
+    }
+
+    /// Test that index() returns None before finishing.
+    ///
+    /// Validates index is only available after successful decode.
+    #[test]
+    fn index_decoder_index_availability() {
+        let mut decoder = Stream::default().index_decoder(u64::MAX).unwrap();
+
+        // Before any processing
+        assert!(decoder.index().is_none());
+
+        // During processing (with invalid data)
+        let test_data = b"not an index";
+        let _ = decoder.process(test_data, Action::Run);
+
+        if !decoder.is_finished() {
+            // Index should not be available yet
+            assert!(decoder.index().is_none());
+        }
+    }
+}

--- a/lzma-safe/src/decoder/mod.rs
+++ b/lzma-safe/src/decoder/mod.rs
@@ -2,10 +2,14 @@
 
 use crate::{Action, Result, Stream};
 
+mod file_info;
+mod index;
 pub mod options;
 #[cfg(test)]
 mod tests;
 
+pub use file_info::FileInfoDecoder;
+pub use index::IndexDecoder;
 pub use options::Options;
 
 /// Safe wrapper around an `lzma_stream` configured for decompression.

--- a/lzma-safe/src/error.rs
+++ b/lzma-safe/src/error.rs
@@ -35,6 +35,9 @@ pub enum Error {
     /// Integrity check type is not supported (`LZMA_UNSUPPORTED_CHECK`).
     UnsupportedCheck,
 
+    /// Application must seek to a new position (`LZMA_SEEK_NEEDED`).
+    SeekNeeded,
+
     /// Fallback for error codes not known to this wrapper.
     Unknown(liblzma_sys::lzma_ret),
 }
@@ -51,6 +54,7 @@ impl fmt::Display for Error {
             Error::BufError => write!(f, "No progress is possible"),
             Error::ProgError => write!(f, "Programming error"),
             Error::UnsupportedCheck => write!(f, "Integrity check type is not supported"),
+            Error::SeekNeeded => write!(f, "Application must seek to a new position"),
             Error::Unknown(code) => write!(f, "Unknown error code: {code}"),
         }
     }
@@ -71,6 +75,7 @@ impl From<liblzma_sys::lzma_ret> for Error {
             liblzma_sys::lzma_ret_LZMA_BUF_ERROR => Error::BufError,
             liblzma_sys::lzma_ret_LZMA_PROG_ERROR => Error::ProgError,
             liblzma_sys::lzma_ret_LZMA_UNSUPPORTED_CHECK => Error::UnsupportedCheck,
+            liblzma_sys::lzma_ret_LZMA_SEEK_NEEDED => Error::SeekNeeded,
             other => Error::Unknown(other),
         }
     }
@@ -89,6 +94,7 @@ impl Error {
             Error::BufError => liblzma_sys::lzma_ret_LZMA_BUF_ERROR,
             Error::ProgError => liblzma_sys::lzma_ret_LZMA_PROG_ERROR,
             Error::UnsupportedCheck => liblzma_sys::lzma_ret_LZMA_UNSUPPORTED_CHECK,
+            Error::SeekNeeded => liblzma_sys::lzma_ret_LZMA_SEEK_NEEDED,
             Error::Unknown(code) => code,
         }
     }
@@ -129,6 +135,7 @@ mod test {
                 liblzma_sys::lzma_ret_LZMA_UNSUPPORTED_CHECK,
                 Error::UnsupportedCheck,
             ),
+            (liblzma_sys::lzma_ret_LZMA_SEEK_NEEDED, Error::SeekNeeded),
         ];
 
         for &(code, ref expected_variant) in &cases {
@@ -177,6 +184,7 @@ mod test {
                 Error::UnsupportedCheck,
                 liblzma_sys::lzma_ret_LZMA_UNSUPPORTED_CHECK,
             ),
+            (Error::SeekNeeded, liblzma_sys::lzma_ret_LZMA_SEEK_NEEDED),
             (Error::Unknown(42), 42),
         ];
 
@@ -210,6 +218,7 @@ mod test {
             liblzma_sys::lzma_ret_LZMA_BUF_ERROR,
             liblzma_sys::lzma_ret_LZMA_PROG_ERROR,
             liblzma_sys::lzma_ret_LZMA_UNSUPPORTED_CHECK,
+            liblzma_sys::lzma_ret_LZMA_SEEK_NEEDED,
             99999, // unknown code
         ];
 

--- a/lzma-safe/src/lib.rs
+++ b/lzma-safe/src/lib.rs
@@ -40,10 +40,10 @@ pub mod stream;
 mod error;
 mod ffi;
 
-pub use decoder::Decoder;
+pub use decoder::{Decoder, FileInfoDecoder, IndexDecoder};
 pub use encoder::Encoder;
 pub use error::{Error, Result};
-pub use stream::Stream;
+pub use stream::{BlockInfo, Index, IndexEntry, IndexIterMode, IndexIterator, Stream, StreamInfo};
 
 /// Access to the liblzma version reported by the linked C library.
 pub struct Version;

--- a/lzma-safe/src/stream/allocator.rs
+++ b/lzma-safe/src/stream/allocator.rs
@@ -92,6 +92,22 @@ impl LzmaAllocator {
     }
 }
 
+impl Clone for LzmaAllocator {
+    fn clone(&self) -> Self {
+        match &self._allocator_box {
+            None => {
+                // Default allocator - just create a new one
+                Self::default()
+            }
+            Some(boxed_arc) => {
+                // Clone the Arc to share the allocator
+                let allocator_arc = Arc::clone(boxed_arc.as_ref());
+                Self::from_allocator(allocator_arc)
+            }
+        }
+    }
+}
+
 impl Drop for LzmaAllocator {
     fn drop(&mut self) {
         // The Box<Arc<dyn Allocator>> will be dropped automatically,

--- a/lzma-safe/src/stream/index.rs
+++ b/lzma-safe/src/stream/index.rs
@@ -1,0 +1,619 @@
+//! Safe RAII wrappers around `lzma_index` and iterators over its contents.
+
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+use crate::encoder::options::IntegrityCheck;
+use crate::ffi;
+use crate::stream::LzmaAllocator;
+
+/// Owned handle to a liblzma `lzma_index`.
+///
+/// The index is freed automatically via [`liblzma_sys::lzma_index_end`] when
+/// this struct is dropped.
+pub struct Index {
+    inner: NonNull<liblzma_sys::lzma_index>,
+    /// Optional custom allocator, kept alive for the stream's lifetime.
+    #[allow(unused)]
+    allocator: Option<LzmaAllocator>,
+}
+
+impl Index {
+    /// Construct an [`Index`] from a raw pointer returned by liblzma.
+    ///
+    /// # Safety
+    ///
+    /// * `ptr` must be a valid pointer obtained from liblzma.
+    /// * The caller relinquishes ownership of the pointer to the returned
+    ///   `Index` instance.
+    /// * If `allocator` is provided, it must be the same allocator that was
+    ///   used to create the index.
+    pub(crate) unsafe fn from_raw(
+        ptr: *mut liblzma_sys::lzma_index,
+        allocator: Option<LzmaAllocator>,
+    ) -> Option<Self> {
+        NonNull::new(ptr).map(|inner| Self { inner, allocator })
+    }
+
+    /// Expose the raw pointer for FFI calls that only need shared access.
+    pub(crate) fn as_ptr(&self) -> *const liblzma_sys::lzma_index {
+        self.inner.as_ptr()
+    }
+
+    /// Return the number of streams stored in the index.
+    pub fn stream_count(&self) -> u64 {
+        ffi::lzma_index_stream_count(self)
+    }
+
+    /// Return the number of blocks stored in the index.
+    pub fn block_count(&self) -> u64 {
+        ffi::lzma_index_block_count(self)
+    }
+
+    /// Return the total compressed size tracked by the index.
+    pub fn file_size(&self) -> u64 {
+        ffi::lzma_index_file_size(self)
+    }
+
+    /// Return the total uncompressed size tracked by the index.
+    pub fn uncompressed_size(&self) -> u64 {
+        ffi::lzma_index_uncompressed_size(self)
+    }
+
+    /// Return the bitmask of integrity checks seen in the index.
+    pub fn checks(&self) -> u32 {
+        ffi::lzma_index_checks(self)
+    }
+
+    /// Create an iterator over items stored in the index.
+    ///
+    /// By default, iterates in [`IndexIterMode::Any`] mode.
+    /// Use [`Index::iter_streams()`] or [`Index::iter_blocks()`] for specific modes.
+    pub fn iter(&self) -> IndexIterator<'_> {
+        IndexIterator::new(self)
+    }
+
+    /// Create an iterator over streams only.
+    pub fn iter_streams(&self) -> IndexIterator<'_> {
+        IndexIterator::with_mode(self, IndexIterMode::Stream)
+    }
+
+    /// Create an iterator over blocks only.
+    pub fn iter_blocks(&self) -> IndexIterator<'_> {
+        IndexIterator::with_mode(self, IndexIterMode::Block)
+    }
+
+    /// Create an iterator over non-empty blocks only.
+    pub fn iter_non_empty_blocks(&self) -> IndexIterator<'_> {
+        IndexIterator::with_mode(self, IndexIterMode::NonEmptyBlock)
+    }
+}
+
+impl Drop for Index {
+    fn drop(&mut self) {
+        ffi::lzma_index_end(self.inner.as_ptr(), self.allocator.as_ref());
+    }
+}
+
+/// Entry returned by [`IndexIterator`].
+#[derive(Debug, Clone)]
+pub enum IndexEntry {
+    /// Stream entry with its information.
+    Stream(StreamInfo),
+    /// Block entry with its information.
+    Block(BlockInfo),
+}
+
+/// Iterator over streams and blocks stored in an [`Index`].
+pub struct IndexIterator<'a> {
+    inner: liblzma_sys::lzma_index_iter,
+    mode: IndexIterMode,
+    _owner: PhantomData<&'a Index>,
+}
+
+impl<'a> IndexIterator<'a> {
+    fn new(index: &'a Index) -> Self {
+        Self::with_mode(index, IndexIterMode::Any)
+    }
+
+    /// Create an iterator with a specific iteration mode.
+    pub fn with_mode(index: &'a Index, mode: IndexIterMode) -> Self {
+        let mut inner = unsafe { std::mem::zeroed::<liblzma_sys::lzma_index_iter>() };
+        // SAFETY: The index pointer is valid and owned by the caller.
+        ffi::lzma_index_iter_init(&mut inner, index);
+
+        Self {
+            inner,
+            mode,
+            _owner: PhantomData,
+        }
+    }
+
+    /// Set the iteration mode for this iterator.
+    pub fn set_mode(&mut self, mode: IndexIterMode) {
+        self.mode = mode;
+    }
+
+    /// Information about the current stream entry.
+    pub fn stream(&self) -> StreamInfo {
+        // SAFETY: The flags pointer comes from liblzma and is valid for the lifetime of the iterator
+        let flags = unsafe { StreamFlags::from_raw(self.inner.stream.flags) };
+
+        StreamInfo {
+            number: self.inner.stream.number,
+            block_count: self.inner.stream.block_count,
+            compressed_offset: self.inner.stream.compressed_offset,
+            uncompressed_offset: self.inner.stream.uncompressed_offset,
+            compressed_size: self.inner.stream.compressed_size,
+            uncompressed_size: self.inner.stream.uncompressed_size,
+            padding: self.inner.stream.padding,
+            flags,
+        }
+    }
+
+    /// Information about the current block entry.
+    pub fn block(&self) -> BlockInfo {
+        BlockInfo {
+            number_in_stream: self.inner.block.number_in_stream,
+            number_in_file: self.inner.block.number_in_file,
+            compressed_file_offset: self.inner.block.compressed_file_offset,
+            uncompressed_file_offset: self.inner.block.uncompressed_file_offset,
+            total_size: self.inner.block.total_size,
+            uncompressed_size: self.inner.block.uncompressed_size,
+            unpadded_size: self.inner.block.unpadded_size,
+        }
+    }
+
+    /// Get the current entry based on the iteration mode.
+    fn current_entry(&self) -> IndexEntry {
+        match self.mode {
+            IndexIterMode::Stream => IndexEntry::Stream(self.stream()),
+            IndexIterMode::Block | IndexIterMode::NonEmptyBlock => IndexEntry::Block(self.block()),
+            IndexIterMode::Any => {
+                // For Any mode, we need to determine what we're currently pointing at
+                // This is a simplification - we'll return Block by default
+                IndexEntry::Block(self.block())
+            }
+        }
+    }
+
+    /// Returns a mutable reference to the underlying raw `lzma_index_iter` struct.
+    #[inline]
+    pub(crate) fn as_mut_raw(&mut self) -> &mut liblzma_sys::lzma_index_iter {
+        &mut self.inner
+    }
+}
+
+impl<'a> Iterator for IndexIterator<'a> {
+    type Item = IndexEntry;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if ffi::lzma_index_iter_next(self, self.mode) {
+            Some(self.current_entry())
+        } else {
+            None
+        }
+    }
+}
+
+/// Iteration mode for [`IndexIterator`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexIterMode {
+    /// Iterate over any entry (streams and blocks).
+    Any,
+    /// Iterate over streams only.
+    Stream,
+    /// Iterate over blocks only.
+    Block,
+    /// Iterate over blocks that contain uncompressed data.
+    NonEmptyBlock,
+}
+
+impl From<IndexIterMode> for liblzma_sys::lzma_index_iter_mode {
+    fn from(mode: IndexIterMode) -> Self {
+        match mode {
+            IndexIterMode::Any => liblzma_sys::lzma_index_iter_mode_LZMA_INDEX_ITER_ANY,
+            IndexIterMode::Stream => liblzma_sys::lzma_index_iter_mode_LZMA_INDEX_ITER_STREAM,
+            IndexIterMode::Block => liblzma_sys::lzma_index_iter_mode_LZMA_INDEX_ITER_BLOCK,
+            IndexIterMode::NonEmptyBlock => {
+                liblzma_sys::lzma_index_iter_mode_LZMA_INDEX_ITER_NONEMPTY_BLOCK
+            }
+        }
+    }
+}
+
+/// Stream flags containing metadata about the stream format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StreamFlags {
+    /// Stream format version (currently always 0).
+    pub version: u32,
+    /// Size of the Index field (in the Stream Footer).
+    /// Set to `None` when read from Stream Header.
+    pub backward_size: Option<u64>,
+    /// Integrity check algorithm used for this stream.
+    pub check: IntegrityCheck,
+}
+
+impl StreamFlags {
+    /// Convert from a raw liblzma stream flags pointer.
+    ///
+    /// # Safety
+    ///
+    /// The pointer must be valid and point to a properly initialized `lzma_stream_flags`.
+    pub(crate) unsafe fn from_raw(ptr: *const liblzma_sys::lzma_stream_flags) -> Option<Self> {
+        if ptr.is_null() {
+            return None;
+        }
+
+        let raw = &*ptr;
+
+        // Try to convert the check type
+        let check = IntegrityCheck::try_from(raw.check).ok()?;
+
+        // backward_size is set to LZMA_VLI_UNKNOWN when not available (e.g., from Stream Header)
+        const LZMA_VLI_UNKNOWN: u64 = u64::MAX;
+        let backward_size = if raw.backward_size == LZMA_VLI_UNKNOWN {
+            None
+        } else {
+            Some(raw.backward_size)
+        };
+
+        Some(Self {
+            version: raw.version,
+            backward_size,
+            check,
+        })
+    }
+}
+
+/// Information about a stream stored within an index.
+#[derive(Debug, Clone)]
+pub struct StreamInfo {
+    /// Stream number (1-based).
+    pub number: u64,
+    /// Number of blocks in the stream.
+    pub block_count: u64,
+    /// Compressed start offset.
+    pub compressed_offset: u64,
+    /// Uncompressed start offset.
+    pub uncompressed_offset: u64,
+    /// Compressed size (without padding).
+    pub compressed_size: u64,
+    /// Uncompressed size.
+    pub uncompressed_size: u64,
+    /// Padding size following the stream.
+    pub padding: u64,
+    /// Stream flags containing format metadata.
+    pub flags: Option<StreamFlags>,
+}
+
+/// Information about a block stored within an index.
+#[derive(Debug, Clone)]
+pub struct BlockInfo {
+    /// Block number within the current stream (1-based).
+    pub number_in_stream: u64,
+    /// Block number within the entire file (1-based).
+    pub number_in_file: u64,
+    /// Compressed start offset within the file.
+    pub compressed_file_offset: u64,
+    /// Uncompressed start offset within the file.
+    pub uncompressed_file_offset: u64,
+    /// Total compressed size (including headers).
+    pub total_size: u64,
+    /// Uncompressed size.
+    pub uncompressed_size: u64,
+    /// Unpadded size.
+    pub unpadded_size: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Action, Stream};
+
+    use super::*;
+
+    /// Helper function to create a FileInfoDecoder with extracted index.
+    ///
+    /// This compresses the provided `data`, then decodes the resulting file info and index.
+    ///
+    /// # Parameters
+    ///
+    /// * `data` - The input data to compress and decode.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(FileInfoDecoder)` with a finished and valid decoder if successful,
+    /// or `None` on error.
+    fn create_test_decoder(data: &[u8]) -> Option<crate::FileInfoDecoder> {
+        use crate::encoder::options::{Compression, IntegrityCheck};
+
+        // Compress input data.
+        let mut encoder = Stream::default()
+            .easy_encoder(Compression::Level6, IntegrityCheck::Crc64)
+            .ok()?;
+
+        // Allocate sufficient buffer for compression output.
+        let mut compressed = vec![0u8; data.len().saturating_mul(2) + 2048];
+        let (_, written) = encoder.process(data, &mut compressed, Action::Run).ok()?;
+        let mut total_written = written;
+
+        // Ensure all data is compressed by finishing the stream.
+        let (_, finish_written) = encoder
+            .process(&[], &mut compressed[total_written..], Action::Finish)
+            .ok()?;
+        total_written += finish_written;
+        compressed.truncate(total_written);
+
+        // Create a decoder to extract the index and file info.
+        let mut decoder = Stream::default()
+            .file_info_decoder(u64::MAX, compressed.len() as u64)
+            .ok()?;
+
+        let mut pos = 0;
+        let mut pending_action = Action::Run;
+        // Drive the decoder with all input, respecting seek requests.
+        while !decoder.is_finished() {
+            match decoder.process(&compressed[pos..], pending_action) {
+                Ok(bytes_read) => {
+                    pos += bytes_read;
+                    // If input is exhausted, switch to Finish action to complete.
+                    if pos >= compressed.len() && pending_action != Action::Finish {
+                        pending_action = Action::Finish;
+                    }
+                }
+                Err(crate::Error::SeekNeeded) => {
+                    // Handle random-access request by updating position.
+                    pos = decoder.seek_pos() as usize;
+                    pending_action = Action::Run; // Always resume with Run after seek.
+                }
+                Err(crate::Error::StreamEnd) => break,
+                Err(_) => return None,
+            }
+
+            // If we've finished processing the buffer and issued Finish, we're done.
+            if pos >= compressed.len() && pending_action == Action::Finish {
+                break;
+            }
+        }
+
+        // Decoder should be finished, and index extractable.
+        Some(decoder)
+    }
+
+    /// Test basic Index creation and accessors.
+    #[test]
+    fn index_basic_accessors() {
+        let test_data = b"Lazzy dog jumps over the lazy fox".repeat(100);
+        let decoder = create_test_decoder(&test_data).unwrap();
+        let index = decoder.index().unwrap();
+
+        // Basic checks
+        assert!(index.stream_count() > 0);
+        assert!(index.block_count() > 0);
+        assert!(index.file_size() > 0);
+        assert!(index.uncompressed_size() > 0);
+        assert_eq!(index.uncompressed_size(), test_data.len() as u64);
+
+        // File size should be smaller than uncompressed for compressible data
+        assert!(index.file_size() < index.uncompressed_size());
+    }
+
+    /// Test Index::checks() returns non-zero value.
+    #[test]
+    fn index_checks_non_zero() {
+        let test_data = b"Lazzy dog jumps over the lazy fox";
+        let decoder = create_test_decoder(test_data).unwrap();
+        let index = decoder.index().unwrap();
+
+        let checks = index.checks();
+        assert_ne!(checks, 0, "Checks should not be zero");
+    }
+
+    /// Test IndexIterator with Stream mode using Iterator trait.
+    #[test]
+    fn index_iterator_streams_trait() {
+        let test_data = b"Lazzy dog jumps over the lazy fox".repeat(50);
+        let decoder = create_test_decoder(&test_data).unwrap();
+        let index = decoder.index().unwrap();
+
+        let streams: Vec<_> = index.iter_streams().collect();
+        assert_eq!(streams.len() as u64, index.stream_count());
+
+        for entry in streams {
+            if let IndexEntry::Stream(stream_info) = entry {
+                assert!(stream_info.block_count > 0);
+                assert!(stream_info.compressed_size > 0);
+                assert!(stream_info.uncompressed_size > 0);
+            } else {
+                panic!("Expected Stream entry");
+            }
+        }
+    }
+
+    /// Test IndexIterator with Block mode using Iterator trait.
+    #[test]
+    fn index_iterator_blocks_trait() {
+        let test_data = b"Lazzy dog jumps over the lazy fox".repeat(50);
+        let decoder = create_test_decoder(&test_data).unwrap();
+        let index = decoder.index().unwrap();
+
+        let blocks: Vec<_> = index.iter_blocks().collect();
+        assert_eq!(blocks.len() as u64, index.block_count());
+
+        for (i, entry) in blocks.iter().enumerate() {
+            if let IndexEntry::Block(block_info) = entry {
+                assert_eq!(block_info.number_in_file, (i + 1) as u64);
+                assert!(block_info.total_size > 0);
+                assert!(block_info.uncompressed_size > 0);
+            } else {
+                panic!("Expected Block entry");
+            }
+        }
+    }
+
+    /// Test IndexIterator with NonEmptyBlock mode using Iterator trait.
+    #[test]
+    fn index_iterator_non_empty_blocks_trait() {
+        let test_data = b"Lazzy dog jumps over the lazy fox".repeat(50);
+        let decoder = create_test_decoder(&test_data).unwrap();
+        let index = decoder.index().unwrap();
+
+        let blocks: Vec<_> = index.iter_non_empty_blocks().collect();
+        assert!(!blocks.is_empty());
+
+        for entry in blocks {
+            if let IndexEntry::Block(block_info) = entry {
+                assert!(block_info.uncompressed_size > 0);
+            } else {
+                panic!("Expected Block entry");
+            }
+        }
+    }
+
+    /// Test IndexIterator with Any mode using Iterator trait.
+    #[test]
+    fn index_iterator_any_trait() {
+        let test_data = b"Lazzy dog jumps over the lazy fox".repeat(50);
+        let decoder = create_test_decoder(&test_data).unwrap();
+        let index = decoder.index().unwrap();
+
+        let entries: Vec<_> = index.iter().collect();
+        assert!(!entries.is_empty(), "Should have at least one entry");
+    }
+
+    /// Test that iterator returns None when no more entries (Iterator trait).
+    #[test]
+    fn index_iterator_returns_none_at_end() {
+        let test_data = b"Lazzy dog jumps over the lazy fox";
+        let decoder = create_test_decoder(test_data).unwrap();
+        let index = decoder.index().unwrap();
+
+        let mut iter = index.iter_blocks();
+
+        // Exhaust the iterator
+        while iter.next().is_some() {}
+
+        // Next call should return None
+        assert!(iter.next().is_none());
+    }
+
+    /// Test StreamInfo fields are populated correctly using Iterator trait.
+    #[test]
+    fn index_iterator_stream_info_fields() {
+        let test_data = b"Lazzy dog jumps over the lazy fox".repeat(100);
+        let decoder = create_test_decoder(&test_data).unwrap();
+        let index = decoder.index().unwrap();
+
+        // Should have at least one stream
+        let entry = index.iter_streams().next().unwrap();
+
+        if let IndexEntry::Stream(stream_info) = entry {
+            // Check all fields are reasonable
+            assert_eq!(stream_info.number, 1);
+            assert!(stream_info.block_count > 0);
+            assert_eq!(stream_info.compressed_offset, 0);
+            assert_eq!(stream_info.uncompressed_offset, 0);
+            assert!(stream_info.compressed_size > 0);
+            assert!(stream_info.uncompressed_size > 0);
+        } else {
+            panic!("Expected Stream entry");
+        }
+    }
+
+    /// Test BlockInfo fields are populated correctly using Iterator trait.
+    #[test]
+    fn index_iterator_block_info_fields() {
+        let test_data = b"Lazzy dog jumps over the lazy fox".repeat(100);
+        let decoder = create_test_decoder(&test_data).unwrap();
+        let index = decoder.index().unwrap();
+
+        // Should have at least one block
+        let entry = index.iter_blocks().next().unwrap();
+
+        if let IndexEntry::Block(block_info) = entry {
+            // Check all fields are reasonable
+            assert_eq!(block_info.number_in_stream, 1);
+            assert_eq!(block_info.number_in_file, 1);
+            // Offsets should be >= 0
+            assert!(block_info.compressed_file_offset > 0);
+            assert_eq!(block_info.uncompressed_file_offset, 0);
+            assert!(block_info.total_size > 0);
+            assert!(block_info.uncompressed_size > 0);
+            assert!(block_info.unpadded_size > 0);
+            // Unpadded size should be <= total size
+            assert!(block_info.unpadded_size <= block_info.total_size);
+        } else {
+            panic!("Expected Block entry");
+        }
+    }
+
+    /// Test creating multiple iterators using Iterator trait.
+    #[test]
+    fn index_multiple_iterators_trait() {
+        let test_data = b"Lazzy dog jumps over the lazy fox";
+        let decoder = create_test_decoder(test_data).unwrap();
+        let index = decoder.index().unwrap();
+
+        // Create first iterator
+        let count1 = index.iter_blocks().count();
+
+        // Create second iterator - should iterate independently
+        let count2 = index.iter_blocks().count();
+
+        assert_eq!(count1, count2);
+        assert_eq!(count1 as u64, index.block_count());
+    }
+
+    /// Test that StreamFlags are properly extracted and parsed.
+    #[test]
+    fn index_stream_flags() {
+        let test_data = b"Lazzy dog jumps over the lazy fox".repeat(10);
+        let decoder = create_test_decoder(&test_data).unwrap();
+        let index = decoder.index().unwrap();
+
+        // Get first stream
+        let entry = index.iter_streams().next().unwrap();
+        if let IndexEntry::Stream(stream_info) = entry {
+            // StreamFlags should be present
+            let flags = stream_info.flags.expect("StreamFlags should be present");
+
+            // Check version (should be 0 for current XZ format)
+            assert_eq!(flags.version, 0);
+
+            // Check that integrity check is valid
+            assert!(matches!(
+                flags.check,
+                IntegrityCheck::None
+                    | IntegrityCheck::Crc32
+                    | IntegrityCheck::Crc64
+                    | IntegrityCheck::Sha256
+            ));
+
+            // backward_size should be present (we're reading from Stream Footer)
+            assert!(flags.backward_size.is_some());
+        } else {
+            panic!("Expected Stream entry");
+        }
+    }
+
+    /// Test IndexIterMode conversion.
+    #[test]
+    fn index_iter_mode_conversion() {
+        use liblzma_sys::*;
+
+        let any: lzma_index_iter_mode = IndexIterMode::Any.into();
+        assert_eq!(any, lzma_index_iter_mode_LZMA_INDEX_ITER_ANY);
+
+        let stream: lzma_index_iter_mode = IndexIterMode::Stream.into();
+        assert_eq!(stream, lzma_index_iter_mode_LZMA_INDEX_ITER_STREAM);
+
+        let block: lzma_index_iter_mode = IndexIterMode::Block.into();
+        assert_eq!(block, lzma_index_iter_mode_LZMA_INDEX_ITER_BLOCK);
+
+        let non_empty: lzma_index_iter_mode = IndexIterMode::NonEmptyBlock.into();
+        assert_eq!(
+            non_empty,
+            lzma_index_iter_mode_LZMA_INDEX_ITER_NONEMPTY_BLOCK
+        );
+    }
+}


### PR DESCRIPTION
- Add `FileInfoDecoder` for extracting metadata from complete XZ files;
- Add `IndexDecoder` for extracting index metadata from XZ Index blocks;
- Update the `Stream` struct to include methods for creating both decoders;
- Add unit tests for the both new decoders.