### PR TITLE
Legacy .lzma (LZMA_Alone): format support, upstream-compatible --lzma1, improved diagnostics, and expanded CLI tests

### DIFF
--- a/lzma-safe/src/encoder/alone.rs
+++ b/lzma-safe/src/encoder/alone.rs
@@ -1,0 +1,121 @@
+//! Legacy `.lzma` (`LZMA_Alone`) encoder.
+//!
+//! This encoder targets the historical `.lzma` file format. It exists for compatibility with
+//! legacy tools and data sets.
+//!
+//! The format supports only LZMA1 and does not include an integrity check field. As a result,
+//! only [`crate::Action::Run`] and [`crate::Action::Finish`] are supported.
+
+use crate::encoder::options::Lzma1Options;
+use crate::{Action, Error, Result, Stream};
+
+/// Streaming encoder for the legacy `.lzma` (`LZMA_Alone`) container format.
+///
+/// This is a thin safe wrapper around `lzma_alone_encoder()` + `lzma_code()`.
+pub struct AloneEncoder {
+    options: Lzma1Options,
+    stream: Option<Stream>,
+    total_in: u64,
+    total_out: u64,
+}
+
+impl AloneEncoder {
+    /// Create a new `.lzma` encoder with the specified LZMA1 options.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::OptionsError`] if the options are invalid for the linked liblzma.
+    pub fn new(options: Lzma1Options, mut stream: Stream) -> Result<Self> {
+        crate::ffi::lzma_alone_encoder(options.as_raw(), &mut stream)?;
+        Ok(Self {
+            options,
+            stream: Some(stream),
+            total_in: 0,
+            total_out: 0,
+        })
+    }
+
+    /// Process input data through the encoder, producing `.lzma` output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::ProgError`] if `action` isn't supported by the `.lzma` container.
+    pub fn process(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        action: Action,
+    ) -> Result<(usize, usize)> {
+        if !matches!(action, Action::Run | Action::Finish) {
+            return Err(Error::ProgError);
+        }
+
+        let Some(mut stream) = self.stream.take() else {
+            if action == Action::Finish {
+                return Err(Error::ProgError);
+            }
+            return Ok((0, 0));
+        };
+
+        if !input.is_empty() {
+            stream.set_next_input(input);
+        }
+        stream.set_next_out(output);
+
+        let input_before = stream.avail_in();
+        let output_before = stream.avail_out();
+
+        let result = crate::ffi::lzma_code(&mut stream, action);
+        let bytes_read = input_before - stream.avail_in();
+        let bytes_written = output_before - stream.avail_out();
+
+        self.total_in = stream.total_in();
+        self.total_out = stream.total_out();
+
+        match result {
+            Ok(()) => {
+                self.stream = Some(stream);
+                Ok((bytes_read, bytes_written))
+            }
+            Err(Error::StreamEnd) => {
+                stream.finish();
+                Ok((bytes_read, bytes_written))
+            }
+            Err(err) => {
+                self.stream = Some(stream);
+                Err(err)
+            }
+        }
+    }
+
+    /// Whether the underlying stream has been closed.
+    pub fn is_finished(&self) -> bool {
+        self.stream.is_none()
+    }
+
+    /// Total number of input bytes consumed.
+    pub fn total_in(&self) -> u64 {
+        self.total_in
+    }
+
+    /// Total number of output bytes emitted.
+    pub fn total_out(&self) -> u64 {
+        self.total_out
+    }
+
+    /// Access to the LZMA1 options used by this encoder.
+    pub fn options(&self) -> &Lzma1Options {
+        &self.options
+    }
+}
+
+impl Drop for AloneEncoder {
+    fn drop(&mut self) {
+        if let Some(stream) = self.stream.take() {
+            stream.finish();
+        }
+    }
+}
+
+// SAFETY: Like `Encoder`, this type owns an independent `lzma_stream`.
+unsafe impl Send for AloneEncoder {}

--- a/lzma-safe/src/encoder/mod.rs
+++ b/lzma-safe/src/encoder/mod.rs
@@ -2,10 +2,12 @@
 
 use crate::{Action, Result, Stream};
 
+mod alone;
 pub mod options;
 #[cfg(test)]
 mod tests;
 
+pub use alone::AloneEncoder;
 pub use options::Options;
 
 /// Safe wrapper around an `lzma_stream` configured for compression.

--- a/lzma-safe/src/encoder/options/lzma1.rs
+++ b/lzma-safe/src/encoder/options/lzma1.rs
@@ -1,0 +1,214 @@
+//! LZMA1 encoder options.
+//!
+//! These settings correspond to `lzma_options_lzma` from liblzma and are used by the legacy
+//! `.lzma` (also known as "`LZMA_Alone`") container format.
+//!
+//! Note that the `.lzma` container supports only LZMA1. There is no integrity check field in the
+//! container, and only the actions [`crate::Action::Run`] and [`crate::Action::Finish`] are valid
+//! when coding.
+
+use crate::encoder::options::Compression;
+use crate::Result;
+
+/// LZMA match finder mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// Fast mode (`LZMA_MODE_FAST`).
+    Fast,
+    /// Normal mode (`LZMA_MODE_NORMAL`).
+    Normal,
+}
+
+impl From<Mode> for liblzma_sys::lzma_mode {
+    fn from(value: Mode) -> Self {
+        match value {
+            Mode::Fast => liblzma_sys::lzma_mode_LZMA_MODE_FAST,
+            Mode::Normal => liblzma_sys::lzma_mode_LZMA_MODE_NORMAL,
+        }
+    }
+}
+
+/// Match finder algorithm selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchFinder {
+    /// Hash chain match finder (`LZMA_MF_HC3`).
+    Hc3,
+    /// Hash chain match finder (`LZMA_MF_HC4`).
+    Hc4,
+    /// Binary tree match finder (`LZMA_MF_BT2`).
+    Bt2,
+    /// Binary tree match finder (`LZMA_MF_BT3`).
+    Bt3,
+    /// Binary tree match finder (`LZMA_MF_BT4`).
+    Bt4,
+}
+
+impl From<MatchFinder> for liblzma_sys::lzma_match_finder {
+    fn from(value: MatchFinder) -> Self {
+        match value {
+            MatchFinder::Hc3 => liblzma_sys::lzma_match_finder_LZMA_MF_HC3,
+            MatchFinder::Hc4 => liblzma_sys::lzma_match_finder_LZMA_MF_HC4,
+            MatchFinder::Bt2 => liblzma_sys::lzma_match_finder_LZMA_MF_BT2,
+            MatchFinder::Bt3 => liblzma_sys::lzma_match_finder_LZMA_MF_BT3,
+            MatchFinder::Bt4 => liblzma_sys::lzma_match_finder_LZMA_MF_BT4,
+        }
+    }
+}
+
+/// Encoder options for LZMA1 (`lzma_options_lzma`).
+#[derive(Clone)]
+pub struct Lzma1Options {
+    raw: liblzma_sys::lzma_options_lzma,
+}
+
+impl std::fmt::Debug for Lzma1Options {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Lzma1Options")
+            .field("dict_size", &self.raw.dict_size)
+            .field("lc", &self.raw.lc)
+            .field("lp", &self.raw.lp)
+            .field("pb", &self.raw.pb)
+            .field("mode", &self.raw.mode)
+            .field("nice_len", &self.raw.nice_len)
+            .field("mf", &self.raw.mf)
+            .field("depth", &self.raw.depth)
+            .finish()
+    }
+}
+
+impl Lzma1Options {
+    /// Build options from an `xz(1)`-compatible preset (levels 0-9 and extreme flag).
+    ///
+    /// This uses `lzma_lzma_preset()` as a starting point.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::OptionsError`] if the preset is not supported by the linked liblzma.
+    pub fn from_preset(preset: Compression) -> Result<Self> {
+        // SAFETY: lzma_options_lzma is a POD type; zeroed init is valid as a baseline.
+        let mut raw: liblzma_sys::lzma_options_lzma = unsafe { std::mem::zeroed() };
+        crate::ffi::lzma_lzma_preset(&mut raw, preset.to_preset())?;
+        Ok(Self { raw })
+    }
+
+    /// Dictionary size in bytes.
+    #[must_use]
+    pub fn with_dict_size(mut self, dict_size: u32) -> Self {
+        self.raw.dict_size = dict_size;
+        self
+    }
+
+    /// Literal context bits (lc).
+    #[must_use]
+    pub fn with_lc(mut self, lc: u32) -> Self {
+        self.raw.lc = lc;
+        self
+    }
+
+    /// Literal position bits (lp).
+    #[must_use]
+    pub fn with_lp(mut self, lp: u32) -> Self {
+        self.raw.lp = lp;
+        self
+    }
+
+    /// Position bits (pb).
+    #[must_use]
+    pub fn with_pb(mut self, pb: u32) -> Self {
+        self.raw.pb = pb;
+        self
+    }
+
+    /// Encoder mode (fast/normal).
+    #[must_use]
+    pub fn with_mode(mut self, mode: Mode) -> Self {
+        self.raw.mode = mode.into();
+        self
+    }
+
+    /// Nice length.
+    #[must_use]
+    pub fn with_nice_len(mut self, nice_len: u32) -> Self {
+        self.raw.nice_len = nice_len;
+        self
+    }
+
+    /// Match finder.
+    #[must_use]
+    pub fn with_match_finder(mut self, mf: MatchFinder) -> Self {
+        self.raw.mf = mf.into();
+        self
+    }
+
+    /// Maximum match finder depth. Use 0 for liblzma defaults.
+    #[must_use]
+    pub fn with_depth(mut self, depth: u32) -> Self {
+        self.raw.depth = depth;
+        self
+    }
+
+    /// Borrow the raw liblzma options.
+    pub(crate) fn as_raw(&self) -> &liblzma_sys::lzma_options_lzma {
+        &self.raw
+    }
+}
+
+impl Default for Lzma1Options {
+    fn default() -> Self {
+        // Prefer a deterministic default and mirror the default preset used elsewhere.
+        Self::from_preset(Compression::Level6).unwrap_or_else(|_| {
+            // If the preset isn't supported (unlikely), fall back to a conservative manual config.
+            // This fallback is best-effort; liblzma will still validate during encoder init.
+            // SAFETY: POD.
+            let mut raw: liblzma_sys::lzma_options_lzma = unsafe { std::mem::zeroed() };
+            raw.dict_size = 8 * 1024 * 1024;
+            raw.lc = 3;
+            raw.lp = 0;
+            raw.pb = 2;
+            raw.mode = liblzma_sys::lzma_mode_LZMA_MODE_NORMAL;
+            raw.nice_len = 64;
+            raw.mf = liblzma_sys::lzma_match_finder_LZMA_MF_BT4;
+            raw.depth = 0;
+            Self { raw }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test that presets can be turned into LZMA1 options.
+    #[test]
+    fn preset_produces_lzma1_options() {
+        let opts = Lzma1Options::from_preset(Compression::Level3).unwrap();
+        assert!(opts.as_raw().dict_size > 0);
+        assert!(opts.as_raw().lc <= 8);
+        assert!(opts.as_raw().lp <= 4);
+        assert!(opts.as_raw().pb <= 4);
+    }
+
+    /// Test builder helpers mutate the underlying structure.
+    #[test]
+    fn builder_helpers_apply_fields() {
+        let opts = Lzma1Options::default()
+            .with_dict_size(1 << 20)
+            .with_lc(4)
+            .with_lp(1)
+            .with_pb(2)
+            .with_mode(Mode::Fast)
+            .with_nice_len(32)
+            .with_match_finder(MatchFinder::Hc4)
+            .with_depth(64);
+
+        let raw = opts.as_raw();
+        assert_eq!(raw.dict_size, 1 << 20);
+        assert_eq!(raw.lc, 4);
+        assert_eq!(raw.lp, 1);
+        assert_eq!(raw.pb, 2);
+        assert_eq!(raw.mode, liblzma_sys::lzma_mode_LZMA_MODE_FAST);
+        assert_eq!(raw.nice_len, 32);
+        assert_eq!(raw.mf, liblzma_sys::lzma_match_finder_LZMA_MF_HC4);
+        assert_eq!(raw.depth, 64);
+    }
+}

--- a/lzma-safe/src/encoder/options/mod.rs
+++ b/lzma-safe/src/encoder/options/mod.rs
@@ -2,10 +2,12 @@
 
 mod check;
 mod filter;
+mod lzma1;
 mod present;
 
 pub use check::IntegrityCheck;
 pub use filter::{FilterConfig, FilterOptions, FilterType, OwnedFilterOptions, RawFilters};
+pub use lzma1::{Lzma1Options, MatchFinder, Mode};
 pub use present::Compression;
 
 /// Options forwarded to `lzma_stream_encoder_mt`.

--- a/lzma-safe/src/encoder/tests.rs
+++ b/lzma-safe/src/encoder/tests.rs
@@ -108,7 +108,9 @@ fn alone_encoder_round_trip() {
 
     let mut decoder = Stream::default().alone_decoder(u64::MAX).unwrap();
     let mut output = vec![0u8; TEST_DATA.len() * 2];
-    let (_, written) = decoder.process(&compressed, &mut output, Action::Finish).unwrap();
+    let (_, written) = decoder
+        .process(&compressed, &mut output, Action::Finish)
+        .unwrap();
     assert_eq!(written, TEST_DATA.len());
     assert_eq!(&output[..written], TEST_DATA);
 }

--- a/lzma-safe/src/error.rs
+++ b/lzma-safe/src/error.rs
@@ -98,6 +98,22 @@ impl Error {
             Error::Unknown(code) => code,
         }
     }
+
+    /// Return an `xz(1)`-style short error message for this error.
+    pub fn xz_message(self) -> &'static str {
+        match self {
+            Error::MemLimitError => "Memory usage limit reached",
+            Error::FormatError => "File format not recognized",
+            Error::OptionsError => "Unsupported options",
+            Error::DataError => "Compressed data is corrupt",
+            Error::BufError => "Unexpected end of input",
+            Error::MemError => "Memory allocation failed",
+            Error::UnsupportedCheck => "Unsupported type of integrity check",
+            Error::ProgError | Error::SeekNeeded | Error::StreamEnd | Error::Unknown(_) => {
+                "Internal error (bug)"
+            }
+        }
+    }
 }
 
 /// Translate a `liblzma` status code into a `Result`.

--- a/lzma-safe/src/ffi.rs
+++ b/lzma-safe/src/ffi.rs
@@ -95,6 +95,31 @@ pub(crate) fn lzma_alone_decoder(memlimit: u64, stream: &mut Stream) -> Result<(
     result_from_lzma_ret(ret, ())
 }
 
+/// Populate `lzma_options_lzma` from an `xz(1)`-compatible preset via `lzma_lzma_preset`.
+pub(crate) fn lzma_lzma_preset(
+    options: &mut liblzma_sys::lzma_options_lzma,
+    preset: u32,
+) -> Result<()> {
+    // SAFETY: `options` is a valid pointer; liblzma writes the output in place.
+    let failed = unsafe { liblzma_sys::lzma_lzma_preset(options, preset) };
+    if failed != 0 {
+        return Err(Error::OptionsError);
+    }
+    Ok(())
+}
+
+/// Initialise a legacy `.lzma` encoder via `lzma_alone_encoder`.
+pub(crate) fn lzma_alone_encoder(
+    options: &liblzma_sys::lzma_options_lzma,
+    stream: &mut Stream,
+) -> Result<()> {
+    // SAFETY:
+    // - The stream is valid and not already initialized.
+    // - `options` is a valid pointer to an initialized options struct.
+    let ret = unsafe { liblzma_sys::lzma_alone_encoder(stream.lzma_stream(), options) };
+    result_from_lzma_ret(ret, ())
+}
+
 /// Initialise an index decoder with `lzma_index_decoder`.
 ///
 /// The index will be made available through the `index_ptr` after decoding completes.

--- a/lzma-safe/src/lib.rs
+++ b/lzma-safe/src/lib.rs
@@ -41,7 +41,7 @@ mod error;
 mod ffi;
 
 pub use decoder::{Decoder, FileInfoDecoder, IndexDecoder};
-pub use encoder::Encoder;
+pub use encoder::{AloneEncoder, Encoder};
 pub use error::{Error, Result};
 pub use stream::{BlockInfo, Index, IndexEntry, IndexIterMode, IndexIterator, Stream, StreamInfo};
 

--- a/lzma-safe/src/stream/mod.rs
+++ b/lzma-safe/src/stream/mod.rs
@@ -137,6 +137,18 @@ impl Stream {
         Encoder::new_mt(options, self)
     }
 
+    /// Create an encoder for the legacy `.lzma` (`LZMA_Alone`) format.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the options are not supported by the linked liblzma.
+    pub fn alone_encoder(
+        self,
+        options: encoder::options::Lzma1Options,
+    ) -> Result<encoder::AloneEncoder> {
+        encoder::AloneEncoder::new(options, self)
+    }
+
     /// Create a decoder with the specified memory limit and flags.
     ///
     /// # Parameters

--- a/xz-cli/bin/lzcat/main.rs
+++ b/xz-cli/bin/lzcat/main.rs
@@ -1,7 +1,7 @@
-//! LZMA/XZ decompression and concatenation utility
+//! LZMA decompression and concatenation utility
 //!
-//! This utility decompresses LZMA/XZ files and outputs the result to stdout,
-//! similar to 'zcat' for gzip files. It can handle multiple files and
+//! This utility decompresses `.lzma` files and outputs the result to stdout,
+//! similar to `zcat` for gzip files. It can handle multiple files and
 //! concatenate their decompressed content.
 
 use std::process;

--- a/xz-cli/bin/lzcat/main.rs
+++ b/xz-cli/bin/lzcat/main.rs
@@ -4,9 +4,28 @@
 //! similar to 'zcat' for gzip files. It can handle multiple files and
 //! concatenate their decompressed content.
 
-use std::io;
+use std::process;
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> io::Result<()> {
-    unreachable!("Not implemented yet");
+mod opts;
+
+use opts::LzCatOpts;
+
+use xz_cli::{format_diagnostic_for_stderr, run_cli};
+
+const PROGRAM_NAME: &str = "lzcat";
+
+fn main() {
+    let opts = LzCatOpts::parse();
+    let config = opts.config();
+
+    let report = run_cli(opts.files(), &config, PROGRAM_NAME);
+    for diagnostic in &report.diagnostics {
+        if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
+            eprintln!("{msg}");
+        }
+    }
+    let code = report.status.code();
+    if code != 0 {
+        process::exit(code);
+    }
 }

--- a/xz-cli/bin/lzcat/opts.rs
+++ b/xz-cli/bin/lzcat/opts.rs
@@ -65,6 +65,7 @@ impl LzCatOpts {
             extreme: false,
             format: xz_core::config::DecodeMode::Auto,
             check: xz_core::options::IntegrityCheck::None,
+            lzma1: None,
             robot: false,
             suffix: None,
             single_stream: false,
@@ -78,5 +79,3 @@ impl LzCatOpts {
         &self.files
     }
 }
-
-

--- a/xz-cli/bin/lzcat/opts.rs
+++ b/xz-cli/bin/lzcat/opts.rs
@@ -42,6 +42,10 @@ pub struct LzCatOpts {
         value_parser = parse_memory_limit
     )]
     memory: Option<u64>,
+
+    /// Decompress only the first stream, ignore remaining input
+    #[arg(long = "single-stream")]
+    single_stream: bool,
 }
 
 impl LzCatOpts {
@@ -68,7 +72,7 @@ impl LzCatOpts {
             lzma1: None,
             robot: false,
             suffix: None,
-            single_stream: false,
+            single_stream: self.single_stream,
             ignore_check: false,
             sparse: false,
         }
@@ -93,6 +97,7 @@ mod tests {
             quiet: 0,
             threads: Some(4),
             memory: Some(1024),
+            single_stream: false,
         };
 
         let config = opts.config();

--- a/xz-cli/bin/lzcat/opts.rs
+++ b/xz-cli/bin/lzcat/opts.rs
@@ -1,0 +1,82 @@
+//! Command line argument parsing for the lzcat utility.
+
+use clap::Parser;
+
+use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
+
+/// LZMA decompression and concatenation utility.
+///
+/// Equivalent to `lzma --decompress --stdout`.
+#[derive(Debug, Parser)]
+#[command(
+    name = "lzcat",
+    version = "0.1.1",
+    about = "Decompress .lzma files to stdout",
+    long_about = "lzcat decompresses files and writes the output to standard output. \
+                 It is equivalent to 'lzma --decompress --stdout'. Multiple files \
+                 are decompressed and concatenated to stdout."
+)]
+pub struct LzCatOpts {
+    /// Files to decompress
+    #[arg(value_name = "FILE")]
+    files: Vec<String>,
+
+    /// Verbose mode
+    #[arg(short = 'v', long = "verbose", conflicts_with = "quiet")]
+    verbose: bool,
+
+    /// Quiet mode (suppress warnings). Use twice to suppress errors too.
+    #[arg(short = 'q', long = "quiet", conflicts_with = "verbose", action = clap::ArgAction::Count)]
+    quiet: u8,
+
+    /// Use at most this many threads
+    #[arg(short = 'T', long = "threads", value_name = "NUM")]
+    threads: Option<usize>,
+
+    /// Memory usage limit for decompression
+    #[arg(
+        short = 'M',
+        long = "memory",
+        alias = "memlimit",
+        value_name = "LIMIT",
+        value_parser = parse_memory_limit
+    )]
+    memory: Option<u64>,
+}
+
+impl LzCatOpts {
+    /// Parse command line arguments.
+    pub fn parse() -> Self {
+        Parser::parse()
+    }
+
+    /// Build CLI configuration from the parsed options.
+    pub fn config(&self) -> CliConfig {
+        CliConfig {
+            mode: OperationMode::Cat,
+            force: false,
+            keep: true,
+            stdout: true,
+            verbose: self.verbose,
+            quiet: self.quiet,
+            level: None,
+            threads: self.threads,
+            memory_limit: self.memory,
+            extreme: false,
+            format: xz_core::config::DecodeMode::Auto,
+            check: xz_core::options::IntegrityCheck::None,
+            robot: false,
+            suffix: None,
+            single_stream: false,
+            ignore_check: false,
+            sparse: false,
+        }
+    }
+
+    /// Files supplied on the command line.
+    pub fn files(&self) -> &[String] {
+        &self.files
+    }
+}
+
+

--- a/xz-cli/bin/lzcat/opts.rs
+++ b/xz-cli/bin/lzcat/opts.rs
@@ -29,7 +29,7 @@ pub struct LzCatOpts {
     #[arg(short = 'q', long = "quiet", conflicts_with = "verbose", action = clap::ArgAction::Count)]
     quiet: u8,
 
-    /// Use at most this many threads
+    /// Use at most this many threads (ignored for .lzma; kept for CLI compatibility)
     #[arg(short = 'T', long = "threads", value_name = "NUM")]
     threads: Option<usize>,
 
@@ -63,7 +63,7 @@ impl LzCatOpts {
             threads: self.threads,
             memory_limit: self.memory,
             extreme: false,
-            format: xz_core::config::DecodeMode::Auto,
+            format: xz_core::config::DecodeMode::Lzma,
             check: xz_core::options::IntegrityCheck::None,
             lzma1: None,
             robot: false,

--- a/xz-cli/bin/lzma/main.rs
+++ b/xz-cli/bin/lzma/main.rs
@@ -4,9 +4,28 @@
 //! serving as a legacy compatibility layer for the older LZMA format.
 //! It supports both compression and decompression operations.
 
-use std::io;
+use std::process;
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> io::Result<()> {
-    unreachable!("Not implemented yet");
+mod opts;
+
+use opts::LzmaOpts;
+
+use xz_cli::{format_diagnostic_for_stderr, run_cli};
+
+const PROGRAM_NAME: &str = "lzma";
+
+fn main() {
+    let opts = LzmaOpts::parse();
+    let config = opts.config();
+
+    let report = run_cli(&opts.files, &config, PROGRAM_NAME);
+    for diagnostic in &report.diagnostics {
+        if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
+            eprintln!("{msg}");
+        }
+    }
+    let code = report.status.code();
+    if code != 0 {
+        process::exit(code);
+    }
 }

--- a/xz-cli/bin/lzma/opts.rs
+++ b/xz-cli/bin/lzma/opts.rs
@@ -84,6 +84,10 @@ pub struct LzmaOpts {
     #[arg(short = 'e', long = "extreme")]
     pub extreme: bool,
 
+    /// LZMA1 encoder options (comma-separated `key=value` list)
+    #[arg(long = "lzma1", value_name = "OPTS", num_args = 0..=1, default_missing_value = "")]
+    pub lzma1: Option<String>,
+
     /// Use at most this many threads (ignored for .lzma; kept for CLI compatibility)
     #[arg(short = 'T', long = "threads", value_name = "NUM")]
     pub threads: Option<usize>,
@@ -159,6 +163,7 @@ impl LzmaOpts {
             extreme: self.extreme,
             format: xz_core::config::DecodeMode::Lzma,
             check: xz_core::options::IntegrityCheck::None,
+            lzma1: self.lzma1.clone(),
             robot: false,
             suffix: None,
             single_stream: self.single_stream,

--- a/xz-cli/bin/lzma/opts.rs
+++ b/xz-cli/bin/lzma/opts.rs
@@ -84,9 +84,13 @@ pub struct LzmaOpts {
     #[arg(short = 'e', long = "extreme")]
     pub extreme: bool,
 
-    /// LZMA1 encoder options (comma-separated `key=value` list)
+    /// LZMA1 encoder options.
     #[arg(long = "lzma1", value_name = "OPTS", num_args = 0..=1, default_missing_value = "")]
     pub lzma1: Option<String>,
+
+    /// Use custom suffix on compressed files
+    #[arg(short = 'S', long = "suffix", value_name = "SUFFIX")]
+    pub suffix: Option<String>,
 
     /// Use at most this many threads (ignored for .lzma; kept for CLI compatibility)
     #[arg(short = 'T', long = "threads", value_name = "NUM")]
@@ -165,7 +169,7 @@ impl LzmaOpts {
             check: xz_core::options::IntegrityCheck::None,
             lzma1: self.lzma1.clone(),
             robot: false,
-            suffix: None,
+            suffix: self.suffix.clone(),
             single_stream: self.single_stream,
             ignore_check: self.ignore_check,
             sparse: !self.no_sparse,

--- a/xz-cli/bin/lzma/opts.rs
+++ b/xz-cli/bin/lzma/opts.rs
@@ -1,0 +1,169 @@
+//! Command line argument parsing for the lzma utility.
+
+use clap::Parser;
+
+use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
+
+/// LZMA compression utility.
+///
+/// This is conceptually equivalent to `xz --format=lzma`.
+#[derive(Parser, Debug)]
+#[command(
+    name = "lzma",
+    version = "0.1.1",
+    about = "Compress or decompress .lzma files",
+    long_about = "lzma is equivalent to 'xz --format=lzma'. It supports streaming \
+                 compression and decompression using the legacy .lzma container format."
+)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct LzmaOpts {
+    /// Files to process
+    #[arg(value_name = "FILE")]
+    pub files: Vec<String>,
+
+    /// Force compression
+    #[arg(short = 'z', long = "compress", conflicts_with_all = ["decompress", "test"])]
+    pub compress: bool,
+
+    /// Force decompression
+    #[arg(
+        short = 'd',
+        long = "decompress",
+        alias = "uncompress",
+        conflicts_with_all = ["compress", "test"]
+    )]
+    pub decompress: bool,
+
+    /// Test compressed file integrity
+    #[arg(short = 't', long = "test", conflicts_with_all = ["compress", "decompress"])]
+    pub test: bool,
+
+    /// Write to standard output and don't delete input files
+    #[arg(short = 'c', long = "stdout", alias = "to-stdout")]
+    pub stdout: bool,
+
+    /// Force overwrite of output file
+    #[arg(short = 'f', long = "force")]
+    pub force: bool,
+
+    /// Keep (don't delete) input files
+    #[arg(short = 'k', long = "keep")]
+    pub keep: bool,
+
+    /// Verbose mode
+    #[arg(short = 'v', long = "verbose", conflicts_with = "quiet")]
+    pub verbose: bool,
+
+    /// Quiet mode (suppress warnings). Use twice to suppress errors too.
+    #[arg(short = 'q', long = "quiet", conflicts_with = "verbose", action = clap::ArgAction::Count)]
+    pub quiet: u8,
+
+    /// Compression preset level 0..9
+    #[arg(short = '0', group = "level")]
+    pub level_0: bool,
+    #[arg(short = '1', group = "level")]
+    pub level_1: bool,
+    #[arg(short = '2', group = "level")]
+    pub level_2: bool,
+    #[arg(short = '3', group = "level")]
+    pub level_3: bool,
+    #[arg(short = '4', group = "level")]
+    pub level_4: bool,
+    #[arg(short = '5', group = "level")]
+    pub level_5: bool,
+    #[arg(short = '6', group = "level")]
+    pub level_6: bool,
+    #[arg(short = '7', group = "level")]
+    pub level_7: bool,
+    #[arg(short = '8', group = "level")]
+    pub level_8: bool,
+    #[arg(short = '9', group = "level")]
+    pub level_9: bool,
+
+    /// Use extreme compression (slower but better compression)
+    #[arg(short = 'e', long = "extreme")]
+    pub extreme: bool,
+
+    /// Use at most this many threads (ignored for .lzma; kept for CLI compatibility)
+    #[arg(short = 'T', long = "threads", value_name = "NUM")]
+    pub threads: Option<usize>,
+
+    /// Memory usage limit for decompression
+    #[arg(
+        short = 'M',
+        long = "memory",
+        alias = "memlimit",
+        value_name = "LIMIT",
+        value_parser = parse_memory_limit
+    )]
+    pub memory: Option<u64>,
+
+    /// Decompress only the first stream, ignore remaining input
+    #[arg(long = "single-stream")]
+    pub single_stream: bool,
+
+    /// Don't verify the integrity check when decompressing
+    #[arg(long = "ignore-check")]
+    pub ignore_check: bool,
+
+    /// Don't create sparse files when decompressing.
+    #[arg(long = "no-sparse")]
+    pub no_sparse: bool,
+}
+
+impl LzmaOpts {
+    /// Parse command line arguments.
+    pub fn parse() -> Self {
+        Parser::parse()
+    }
+
+    fn operation_mode(&self) -> OperationMode {
+        if self.decompress {
+            OperationMode::Decompress
+        } else if self.test {
+            OperationMode::Test
+        } else {
+            OperationMode::Compress
+        }
+    }
+
+    fn compression_level(&self) -> Option<u32> {
+        [
+            (self.level_0, 0),
+            (self.level_1, 1),
+            (self.level_2, 2),
+            (self.level_3, 3),
+            (self.level_4, 4),
+            (self.level_5, 5),
+            (self.level_6, 6),
+            (self.level_7, 7),
+            (self.level_8, 8),
+            (self.level_9, 9),
+        ]
+        .iter()
+        .find_map(|&(flag, level)| flag.then_some(level))
+    }
+
+    /// Build CLI configuration from the parsed options.
+    pub fn config(&self) -> CliConfig {
+        CliConfig {
+            mode: self.operation_mode(),
+            force: self.force,
+            keep: self.keep,
+            stdout: self.stdout,
+            verbose: self.verbose,
+            quiet: self.quiet,
+            level: self.compression_level(),
+            threads: self.threads,
+            memory_limit: self.memory,
+            extreme: self.extreme,
+            format: xz_core::config::DecodeMode::Lzma,
+            check: xz_core::options::IntegrityCheck::None,
+            robot: false,
+            suffix: None,
+            single_stream: self.single_stream,
+            ignore_check: self.ignore_check,
+            sparse: !self.no_sparse,
+        }
+    }
+}

--- a/xz-cli/bin/unlzma/main.rs
+++ b/xz-cli/bin/unlzma/main.rs
@@ -4,9 +4,28 @@
 //! tool for the LZMA format. It's equivalent to 'lzma -d' but provides a
 //! more convenient interface for decompression-only operations.
 
-use std::io;
+use std::process;
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> io::Result<()> {
-    unreachable!("Not implemented yet");
+mod opts;
+
+use opts::UnlzmaOpts;
+
+use xz_cli::{format_diagnostic_for_stderr, run_cli};
+
+const PROGRAM_NAME: &str = "unlzma";
+
+fn main() {
+    let opts = UnlzmaOpts::parse();
+    let config = opts.config();
+
+    let report = run_cli(opts.files(), &config, PROGRAM_NAME);
+    for diagnostic in &report.diagnostics {
+        if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
+            eprintln!("{msg}");
+        }
+    }
+    let code = report.status.code();
+    if code != 0 {
+        process::exit(code);
+    }
 }

--- a/xz-cli/bin/unlzma/opts.rs
+++ b/xz-cli/bin/unlzma/opts.rs
@@ -1,0 +1,106 @@
+//! Command line argument parsing for the unlzma utility.
+
+use clap::Parser;
+
+use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
+
+/// LZMA decompression utility.
+///
+/// Equivalent to `lzma --decompress`.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Parser)]
+#[command(
+    name = "unlzma",
+    version = "0.1.1",
+    about = "Decompress .lzma files",
+    long_about = "unlzma is equivalent to 'lzma --decompress'. It decompresses files \
+                 created by lzma and removes the .lzma suffix from the filename."
+)]
+pub struct UnlzmaOpts {
+    /// Files to decompress
+    #[arg(value_name = "FILE")]
+    files: Vec<String>,
+
+    /// Write to standard output and don't delete input files
+    #[arg(short = 'c', long = "stdout", alias = "to-stdout")]
+    stdout: bool,
+
+    /// Force overwrite of output file
+    #[arg(short = 'f', long = "force")]
+    force: bool,
+
+    /// Keep (don't delete) input files
+    #[arg(short = 'k', long = "keep")]
+    keep: bool,
+
+    /// Verbose mode
+    #[arg(short = 'v', long = "verbose")]
+    verbose: bool,
+
+    /// Quiet mode (suppress warnings). Use twice to suppress errors too.
+    #[arg(short = 'q', long = "quiet", conflicts_with = "verbose", action = clap::ArgAction::Count)]
+    pub quiet: u8,
+
+    /// Test compressed file integrity
+    #[arg(short = 't', long = "test")]
+    test: bool,
+
+    /// Use at most this many threads
+    #[arg(short = 'T', long = "threads", value_name = "NUM")]
+    threads: Option<usize>,
+
+    /// Memory usage limit for decompression
+    #[arg(
+        short = 'M',
+        long = "memory",
+        alias = "memlimit",
+        value_name = "LIMIT",
+        value_parser = parse_memory_limit
+    )]
+    memory: Option<u64>,
+
+    /// Don't create sparse files when decompressing.
+    #[arg(long = "no-sparse")]
+    no_sparse: bool,
+}
+
+impl UnlzmaOpts {
+    /// Parse command line arguments.
+    pub fn parse() -> Self {
+        Parser::parse()
+    }
+
+    /// Build CLI configuration from the parsed options.
+    pub fn config(&self) -> CliConfig {
+        let mode = if self.test {
+            OperationMode::Test
+        } else {
+            OperationMode::Decompress
+        };
+
+        CliConfig {
+            mode,
+            force: self.force,
+            keep: self.keep,
+            stdout: self.stdout,
+            verbose: self.verbose,
+            quiet: self.quiet,
+            level: None,
+            threads: self.threads,
+            memory_limit: self.memory,
+            extreme: false,
+            format: xz_core::config::DecodeMode::Lzma,
+            check: xz_core::options::IntegrityCheck::None,
+            robot: false,
+            suffix: None,
+            single_stream: false,
+            ignore_check: false,
+            sparse: !self.no_sparse,
+        }
+    }
+
+    /// Files supplied on the command line.
+    pub fn files(&self) -> &[String] {
+        &self.files
+    }
+}

--- a/xz-cli/bin/unlzma/opts.rs
+++ b/xz-cli/bin/unlzma/opts.rs
@@ -45,7 +45,7 @@ pub struct UnlzmaOpts {
     #[arg(short = 't', long = "test")]
     test: bool,
 
-    /// Use at most this many threads
+    /// Use at most this many threads (ignored for .lzma; kept for CLI compatibility)
     #[arg(short = 'T', long = "threads", value_name = "NUM")]
     threads: Option<usize>,
 

--- a/xz-cli/bin/unlzma/opts.rs
+++ b/xz-cli/bin/unlzma/opts.rs
@@ -91,6 +91,7 @@ impl UnlzmaOpts {
             extreme: false,
             format: xz_core::config::DecodeMode::Lzma,
             check: xz_core::options::IntegrityCheck::None,
+            lzma1: None,
             robot: false,
             suffix: None,
             single_stream: false,

--- a/xz-cli/bin/unlzma/opts.rs
+++ b/xz-cli/bin/unlzma/opts.rs
@@ -59,6 +59,10 @@ pub struct UnlzmaOpts {
     )]
     memory: Option<u64>,
 
+    /// Use custom suffix on compressed files
+    #[arg(short = 'S', long = "suffix", value_name = "SUFFIX")]
+    suffix: Option<String>,
+
     /// Don't create sparse files when decompressing.
     #[arg(long = "no-sparse")]
     no_sparse: bool,
@@ -93,7 +97,7 @@ impl UnlzmaOpts {
             check: xz_core::options::IntegrityCheck::None,
             lzma1: None,
             robot: false,
-            suffix: None,
+            suffix: self.suffix.clone(),
             single_stream: false,
             ignore_check: false,
             sparse: !self.no_sparse,

--- a/xz-cli/bin/unxz/opts.rs
+++ b/xz-cli/bin/unxz/opts.rs
@@ -96,6 +96,7 @@ impl UnxzOpts {
             extreme: false,
             format: xz_core::config::DecodeMode::Auto,
             check: xz_core::options::IntegrityCheck::Crc64,
+            lzma1: None,
             robot: false,
             suffix: None,
             single_stream: false,

--- a/xz-cli/bin/xz/main.rs
+++ b/xz-cli/bin/xz/main.rs
@@ -9,7 +9,7 @@ mod opts;
 
 use opts::XzOpts;
 
-use xz_cli::{argfiles, Diagnostic, DiagnosticCause, Error, Result};
+use xz_cli::{argfiles, Diagnostic, DiagnosticCause, Error, IoErrorNoCode, Result};
 use xz_cli::{format_diagnostic_for_stderr, run_cli};
 
 const PROGRAM_NAME: &str = "xz";
@@ -60,8 +60,7 @@ fn resolve_input_files(opts: &XzOpts) -> Result<Vec<String>> {
         let extra =
             argfiles::read_files(Some(path), argfiles::Delimiter::Line).map_err(|source| {
                 DiagnosticCause::Error(Error::OpenInput {
-                    path: path.to_string(),
-                    source,
+                    source: IoErrorNoCode::new(source),
                 })
             })?;
         files.extend(extra);
@@ -71,8 +70,7 @@ fn resolve_input_files(opts: &XzOpts) -> Result<Vec<String>> {
         let extra =
             argfiles::read_files(Some(path), argfiles::Delimiter::Nul).map_err(|source| {
                 DiagnosticCause::Error(Error::OpenInput {
-                    path: path.to_string(),
-                    source,
+                    source: IoErrorNoCode::new(source),
                 })
             })?;
         files.extend(extra);

--- a/xz-cli/bin/xz/opts.rs
+++ b/xz-cli/bin/xz/opts.rs
@@ -130,6 +130,10 @@ pub struct XzOpts {
     #[arg(short = 'C', long = "check", value_name = "TYPE")]
     pub check: Option<String>,
 
+    /// LZMA1 encoder options (only used with `--format=lzma`)
+    #[arg(long = "lzma1", value_name = "OPTS", num_args = 0..=1, default_missing_value = "")]
+    pub lzma1: Option<String>,
+
     /// Read filenames from file (one per line)
     #[arg(
         long = "files",
@@ -223,8 +227,8 @@ impl XzOpts {
             }
             (_, Some("none")) => Ok(IntegrityCheck::None),
             (_, Some("crc32")) => Ok(IntegrityCheck::Crc32),
-            (_, Some("crc64")) => Ok(IntegrityCheck::Crc64),
-            (_, Some("sha256") | None) => Ok(IntegrityCheck::Sha256),
+            (_, Some("crc64") | None) => Ok(IntegrityCheck::Crc64),
+            (_, Some("sha256")) => Ok(IntegrityCheck::Sha256),
             (_, Some(invalid)) => {
                 Err(format!("{invalid}: Unsupported integrity check type").into())
             }
@@ -265,6 +269,7 @@ impl XzOpts {
             extreme: self.extreme,
             format,
             check: self.check_type_for_format(format)?,
+            lzma1: self.lzma1.clone(),
             robot: self.robot,
             suffix: self.suffix.clone(),
             single_stream: self.single_stream,
@@ -306,6 +311,7 @@ mod tests {
             extreme: false,
             format: None,
             check: None,
+            lzma1: None,
             files_from_file: None,
             files0_from_file: None,
             robot: false,

--- a/xz-cli/bin/xzcat/opts.rs
+++ b/xz-cli/bin/xzcat/opts.rs
@@ -65,6 +65,7 @@ impl XzCatOpts {
             extreme: false,
             format: xz_core::config::DecodeMode::Auto,
             check: xz_core::options::IntegrityCheck::Crc64,
+            lzma1: None,
             robot: false,
             suffix: None,
             single_stream: false,

--- a/xz-cli/bin/xzcat/opts.rs
+++ b/xz-cli/bin/xzcat/opts.rs
@@ -42,6 +42,10 @@ pub struct XzCatOpts {
         value_parser = parse_memory_limit
     )]
     memory: Option<u64>,
+
+    /// Decompress only the first stream, ignore remaining input
+    #[arg(long = "single-stream")]
+    single_stream: bool,
 }
 
 impl XzCatOpts {
@@ -68,7 +72,7 @@ impl XzCatOpts {
             lzma1: None,
             robot: false,
             suffix: None,
-            single_stream: false,
+            single_stream: self.single_stream,
             ignore_check: false,
             sparse: false,
         }
@@ -92,6 +96,7 @@ mod tests {
             quiet: 0,
             threads: Some(4),
             memory: Some(1024),
+            single_stream: false,
         };
 
         let config = opts.config();
@@ -112,6 +117,13 @@ mod tests {
         assert!(opts.verbose);
         assert_eq!(opts.threads, Some(2));
         assert_eq!(opts.memory, Some(512 * 1024));
+    }
+
+    #[test]
+    fn parse_single_stream_flag() {
+        let opts = XzCatOpts::try_parse_from(["xzcat", "--single-stream", "input.xz"]).unwrap();
+        assert_eq!(opts.files(), ["input.xz"]);
+        assert!(opts.single_stream);
     }
 
     #[test]

--- a/xz-cli/bin/xzdec/opts.rs
+++ b/xz-cli/bin/xzdec/opts.rs
@@ -76,6 +76,7 @@ impl XzDecOpts {
             extreme: false,
             format: xz_core::config::DecodeMode::Auto,
             check: xz_core::options::IntegrityCheck::Crc64,
+            lzma1: None,
             robot: false,
             suffix: None,
             single_stream: false,

--- a/xz-cli/config.rs
+++ b/xz-cli/config.rs
@@ -55,6 +55,8 @@ pub struct CliConfig {
     pub format: DecodeMode,
     /// Integrity check type
     pub check: IntegrityCheck,
+    /// Optional LZMA1 encoder options string (from `--lzma1[=OPTS]`)
+    pub lzma1: Option<String>,
     /// Machine-readable output
     pub robot: bool,
     /// Custom suffix for compressed files
@@ -82,6 +84,7 @@ impl Default for CliConfig {
             extreme: false,
             format: DecodeMode::Auto,
             check: IntegrityCheck::Crc64,
+            lzma1: None,
             robot: false,
             suffix: None,
             single_stream: false,

--- a/xz-cli/error.rs
+++ b/xz-cli/error.rs
@@ -5,6 +5,47 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
+/// Formats `std::io::Error` similar to `strerror(3)` output, without the trailing
+/// `"(os error N)"` suffix that Rust includes by default.
+#[derive(Debug)]
+pub struct IoErrorNoCode {
+    inner: io::Error,
+}
+
+impl IoErrorNoCode {
+    /// Creates a new wrapper around an I/O error.
+    pub fn new(inner: io::Error) -> Self {
+        Self { inner }
+    }
+
+    /// Returns the underlying I/O error kind.
+    pub fn kind(&self) -> io::ErrorKind {
+        self.inner.kind()
+    }
+}
+
+impl std::fmt::Display for IoErrorNoCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut msg = self.inner.to_string();
+
+        // Rust formats OS errors as "X (os error N)" which doesn't match upstream xz tools.
+        // Strip that suffix when present.
+        if msg.ends_with(')') {
+            if let Some(idx) = msg.rfind(" (os error ") {
+                msg.truncate(idx);
+            }
+        }
+
+        write!(f, "{msg}")
+    }
+}
+
+impl std::error::Error for IoErrorNoCode {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.inner)
+    }
+}
+
 /// Severity of a CLI diagnostic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Severity {
@@ -150,14 +191,14 @@ pub fn format_diagnostic_for_stderr(quiet: u8, diagnostic: &Diagnostic) -> Optio
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum Warning {
     /// Input file lacks recognized compression extension
-    #[error("{}: Filename has an unknown suffix, skipping", path.display())]
+    #[error("Filename has an unknown suffix, skipping")]
     InvalidExtension {
         /// Path to the input file
         path: PathBuf,
     },
 
     /// Input file already has the target suffix
-    #[error("{}: Already has `{}` suffix, skipping", path.display(), suffix)]
+    #[error("Already has `{}` suffix, skipping", suffix)]
     AlreadyHasSuffix {
         /// Path to the input file
         path: PathBuf,
@@ -170,13 +211,11 @@ pub enum Warning {
 #[derive(Debug, Error)]
 pub enum Error {
     /// Failed to open input file
-    #[error("{path}: {source}")]
+    #[error("{source}")]
     OpenInput {
-        /// Path to the input file
-        path: String,
         /// Underlying I/O error
         #[source]
-        source: io::Error,
+        source: IoErrorNoCode,
     },
 
     /// Failed to create output file
@@ -186,7 +225,7 @@ pub enum Error {
         path: PathBuf,
         /// Underlying I/O error
         #[source]
-        source: io::Error,
+        source: IoErrorNoCode,
     },
 
     /// Output file already exists
@@ -197,26 +236,22 @@ pub enum Error {
     },
 
     /// Cannot determine output filename
-    #[error("{}: Cannot determine output filename", path.display())]
+    #[error("Cannot determine output filename")]
     InvalidOutputFilename {
         /// Path to the input file
         path: PathBuf,
     },
 
     /// Compression operation failed
-    #[error("{path}: Compressed data is corrupt")]
+    #[error("{message}")]
     Compression {
-        /// Path to the file being compressed
-        path: String,
         /// Error message from liblzma
         message: String,
     },
 
     /// Decompression operation failed
-    #[error("{path}: Compressed data is corrupt")]
+    #[error("{message}")]
     Decompression {
-        /// Path to the file being decompressed
-        path: String,
         /// Error message from liblzma
         message: String,
     },
@@ -243,13 +278,11 @@ pub enum Error {
     },
 
     /// Failed to remove input file
-    #[error("{path}: Cannot remove: {source}")]
+    #[error("Cannot remove: {source}")]
     RemoveFile {
-        /// Path to the file
-        path: String,
         /// Underlying I/O error
         #[source]
-        source: io::Error,
+        source: IoErrorNoCode,
     },
 
     /// Invalid memory limit format
@@ -274,7 +307,7 @@ pub enum Error {
     WriteOutput {
         /// Underlying I/O error.
         #[source]
-        source: io::Error,
+        source: IoErrorNoCode,
     },
 }
 

--- a/xz-cli/error.rs
+++ b/xz-cli/error.rs
@@ -228,6 +228,13 @@ pub enum Error {
         level: u32,
     },
 
+    /// Invalid option combination or value.
+    #[error("{message}")]
+    InvalidOption {
+        /// Error message describing why the option is invalid.
+        message: String,
+    },
+
     /// Thread count too large
     #[error("The number of threads must not exceed {}", u32::MAX)]
     InvalidThreadCount {

--- a/xz-cli/format/list.rs
+++ b/xz-cli/format/list.rs
@@ -2,7 +2,7 @@
 
 use std::io;
 
-use crate::error::{DiagnosticCause, Error, Result};
+use crate::error::{DiagnosticCause, Error, IoErrorNoCode, Result};
 use crate::utils::{bytes, math};
 use xz_core::file_info::{BlockInfo, StreamInfo};
 
@@ -66,8 +66,11 @@ fn write_stdout_line(line: &str) -> Result<()> {
     use std::io::Write;
 
     let mut out = io::stdout().lock();
-    writeln!(out, "{line}")
-        .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
+    writeln!(out, "{line}").map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
     Ok(())
 }
 
@@ -132,7 +135,11 @@ pub(crate) fn write_list_header_if_needed(ctx: ListOutputContext) -> Result<()> 
         out,
         "Strms  Blocks   Compressed Uncompressed  Ratio  Check   Filename"
     )
-    .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
+    .map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
     Ok(())
 }
 
@@ -166,7 +173,11 @@ pub(crate) fn write_list_row(summary: ListSummary, input_path: &str) -> Result<(
         check,
         input_path
     )
-    .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
+    .map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
     Ok(())
 }
 
@@ -186,6 +197,7 @@ pub(crate) fn write_list_row(summary: ListSummary, input_path: &str) -> Result<(
 /// # Returns
 ///
 /// Returns `Ok(())` on success, or an error if writing to stdout fails.
+#[allow(clippy::too_many_lines)]
 pub(crate) fn write_verbose_report(
     input_path: &str,
     ctx: ListOutputContext,
@@ -200,42 +212,76 @@ pub(crate) fn write_verbose_report(
     let padding_total: u64 = streams.iter().map(|s| s.padding).sum();
 
     let mut out = io::stdout().lock();
-    writeln!(out, "{input_path} ({}/{})", ctx.file_index, ctx.file_count)
-        .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
-    writeln!(out, "  Streams:           {}", summary.stream_count)
-        .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
-    writeln!(out, "  Blocks:            {}", summary.block_count)
-        .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
+    writeln!(out, "{input_path} ({}/{})", ctx.file_index, ctx.file_count).map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
+    writeln!(out, "  Streams:           {}", summary.stream_count).map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
+    writeln!(out, "  Blocks:            {}", summary.block_count).map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
     writeln!(
         out,
         "  Compressed size:   {}",
         bytes::format_list_size_with_bytes(summary.compressed)
     )
-    .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
+    .map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
     writeln!(
         out,
         "  Uncompressed size: {}",
         bytes::format_list_size_with_bytes(summary.uncompressed)
     )
-    .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
-    writeln!(out, "  Ratio:             {ratio:.3}")
-        .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
-    writeln!(out, "  Check:             {check}")
-        .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
+    .map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
+    writeln!(out, "  Ratio:             {ratio:.3}").map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
+    writeln!(out, "  Check:             {check}").map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
     writeln!(
         out,
         "  Stream Padding:    {}",
         bytes::format_list_size(padding_total)
     )
-    .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
+    .map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
 
-    writeln!(out, "  Streams:")
-        .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
+    writeln!(out, "  Streams:").map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
     writeln!(
         out,
         "    Stream    Blocks      CompOffset    UncompOffset        CompSize      UncompSize  Ratio  Check      Padding"
     )
-    .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
+    .map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
 
     for stream in streams {
         let stream_ratio = math::ratio_fraction(stream.compressed_size, stream.uncompressed_size);
@@ -252,16 +298,27 @@ pub(crate) fn write_verbose_report(
             check,
             stream.padding
         )
-        .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
+        .map_err(|source| {
+            DiagnosticCause::from(Error::WriteOutput {
+                source: IoErrorNoCode::new(source),
+            })
+        })?;
     }
 
-    writeln!(out, "  Blocks:")
-        .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
+    writeln!(out, "  Blocks:").map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
     writeln!(
         out,
         "    Stream     Block      CompOffset    UncompOffset       TotalSize      UncompSize  Ratio  Check"
     )
-    .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
+    .map_err(|source| {
+        DiagnosticCause::from(Error::WriteOutput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
 
     let mut stream_idx: usize = 0;
     let mut remaining_in_stream: u64 = streams.get(stream_idx).map_or(0, |s| s.block_count);
@@ -287,7 +344,11 @@ pub(crate) fn write_verbose_report(
             block_ratio,
             check
         )
-        .map_err(|source| DiagnosticCause::from(Error::WriteOutput { source }))?;
+        .map_err(|source| {
+            DiagnosticCause::from(Error::WriteOutput {
+                source: IoErrorNoCode::new(source),
+            })
+        })?;
     }
 
     Ok(())

--- a/xz-cli/io/mod.rs
+++ b/xz-cli/io/mod.rs
@@ -60,6 +60,7 @@ pub fn generate_output_filename(
     input: &Path,
     mode: OperationMode,
     suffix: Option<&str>,
+    default_extension: &str,
     force: bool,
 ) -> Result<PathBuf> {
     match mode {
@@ -68,7 +69,7 @@ pub fn generate_output_filename(
             // Strip leading dot from suffix if present
             let extension = suffix
                 .map(|s| s.strip_prefix('.').unwrap_or(s))
-                .unwrap_or(XZ_EXTENSION);
+                .unwrap_or(default_extension);
 
             // Check if the file already has the target suffix (unless force is enabled)
             if !force {

--- a/xz-cli/io/mod.rs
+++ b/xz-cli/io/mod.rs
@@ -67,9 +67,7 @@ pub fn generate_output_filename(
         OperationMode::Compress => {
             let mut output = input.to_path_buf();
             // Strip leading dot from suffix if present
-            let extension = suffix
-                .map(|s| s.strip_prefix('.').unwrap_or(s))
-                .unwrap_or(default_extension);
+            let extension = suffix.map_or(default_extension, |s| s.strip_prefix('.').unwrap_or(s));
 
             // Check if the file already has the target suffix (unless force is enabled)
             if !force {

--- a/xz-cli/io/mod.rs
+++ b/xz-cli/io/mod.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::config::{CliConfig, OperationMode, DEFAULT_BUFFER_SIZE, LZMA_EXTENSION, XZ_EXTENSION};
-use crate::error::{DiagnosticCause, Error, Result, Warning};
+use crate::error::{DiagnosticCause, Error, IoErrorNoCode, Result, Warning};
 
 mod sparse_writer;
 
@@ -169,8 +169,7 @@ pub fn open_input(path: &str) -> Result<Box<dyn io::Read>> {
     } else {
         let file = File::open(path).map_err(|source| {
             DiagnosticCause::from(Error::OpenInput {
-                path: path.to_string(),
-                source,
+                source: IoErrorNoCode::new(source),
             })
         })?;
         Ok(Box::new(io::BufReader::with_capacity(
@@ -219,7 +218,7 @@ pub fn open_output(path: Option<&Path>, config: &CliConfig) -> Result<Box<dyn io
         let file = File::create(path).map_err(|source| {
             DiagnosticCause::from(Error::CreateOutput {
                 path: path.to_path_buf(),
-                source,
+                source: IoErrorNoCode::new(source),
             })
         })?;
 
@@ -254,7 +253,7 @@ pub(crate) fn open_output_file(path: &Path, config: &CliConfig) -> Result<File> 
     File::create(path).map_err(|source| {
         DiagnosticCause::from(Error::CreateOutput {
             path: path.to_path_buf(),
-            source,
+            source: IoErrorNoCode::new(source),
         })
     })
 }

--- a/xz-cli/io/tests.rs
+++ b/xz-cli/io/tests.rs
@@ -57,9 +57,9 @@ fn sparse_writer_keeps_data_around_hole() {
     w.write_all(b"XYZ").unwrap();
     w.flush().unwrap();
 
-    let expected_len = 3 + 8192 + 3;
+    let expected_len: u64 = 3 + 8192 + 3;
     let meta = std::fs::metadata(&path).unwrap();
-    assert_eq!(meta.len(), expected_len as u64);
+    assert_eq!(meta.len(), expected_len);
 
     let mut f = File::open(&path).unwrap();
     let mut buf = [0u8; 3];
@@ -115,9 +115,9 @@ fn sparse_writer_handles_zero_runs_split_across_writes() {
     w.write_all(b"XYZ").unwrap();
     w.flush().unwrap();
 
-    let expected_len = 3 + 64 + 3;
+    let expected_len: u64 = 3 + 64 + 3;
     let meta = std::fs::metadata(&path).unwrap();
-    assert_eq!(meta.len(), expected_len as u64);
+    assert_eq!(meta.len(), expected_len);
 
     let mut f = File::open(&path).unwrap();
     f.seek(SeekFrom::Start(3)).unwrap();

--- a/xz-cli/lib.rs
+++ b/xz-cli/lib.rs
@@ -8,6 +8,7 @@ mod config;
 mod error;
 mod format;
 mod io;
+mod lzma1;
 mod operations;
 mod process;
 mod utils;

--- a/xz-cli/lib.rs
+++ b/xz-cli/lib.rs
@@ -18,8 +18,8 @@ mod tests;
 
 pub use config::{CliConfig, OperationMode, DEFAULT_BUFFER_SIZE, LZMA_EXTENSION, XZ_EXTENSION};
 pub use error::{
-    format_diagnostic_for_stderr, Diagnostic, DiagnosticCause, Error, ExitStatus, Report, Result,
-    Severity, Warning,
+    format_diagnostic_for_stderr, Diagnostic, DiagnosticCause, Error, ExitStatus, IoErrorNoCode,
+    Report, Result, Severity, Warning,
 };
 pub use io::{generate_output_filename, has_compression_extension, open_input, open_output};
 pub use operations::{compress_file, decompress_file};

--- a/xz-cli/lzma1.rs
+++ b/xz-cli/lzma1.rs
@@ -1,0 +1,244 @@
+//! Parsing helpers for `--lzma1[=OPTS]`.
+//!
+//! Upstream `xz` accepts a comma-separated list of key=value pairs.
+//! This module implements a compatible subset intended for `.lzma` encoding.
+
+use std::result;
+
+use xz_core::options::lzma1::{MatchFinder, Mode};
+use xz_core::options::Compression;
+
+use crate::Error;
+
+type ParseResult<T> = result::Result<T, Error>;
+
+/// Parsed representation of `--lzma1` options.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CliOptions {
+    /// Preset compression level (e.g. `6`, `6e`).
+    pub preset: Option<Compression>,
+    /// Dictionary size in bytes (supports `K/M/G` and `KiB/MiB/GiB` suffixes).
+    pub dict_size: Option<u32>,
+    /// Number of literal context bits.
+    pub lc: Option<u32>,
+    /// Number of literal position bits.
+    pub lp: Option<u32>,
+    /// Number of position bits.
+    pub pb: Option<u32>,
+    /// Encoder mode (`fast` or `normal`).
+    pub mode: Option<Mode>,
+    /// Nice length (match length limit).
+    pub nice_len: Option<u32>,
+    /// Match finder.
+    pub mf: Option<MatchFinder>,
+    /// Match finder search depth.
+    pub depth: Option<u32>,
+}
+
+/// Parse an `xz --lzma1` options string.
+///
+/// The syntax follows upstream `xz`: a comma-separated list of `key=value` pairs.
+///
+/// # Parameters
+///
+/// - `input`: The raw `--lzma1` option string (the part after `=`).
+///
+/// # Returns
+///
+/// Returns parsed overrides. Missing keys are returned as `None`.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::InvalidOption`] when the string is malformed, contains unknown keys,
+/// or any value is out of range.
+pub fn parse_lzma1_options(input: &str) -> ParseResult<CliOptions> {
+    let mut out = CliOptions::default();
+    let input = input.trim();
+    if input.is_empty() {
+        return Ok(out);
+    }
+
+    for part in input.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (key, value) = part.split_once('=').ok_or_else(|| {
+            invalid_option(format!(
+                "invalid --lzma1 option '{part}': expected key=value"
+            ))
+        })?;
+        let key = key.trim();
+        let value = value.trim();
+        if value.is_empty() {
+            return Err(invalid_option(format!(
+                "invalid --lzma1 option '{part}': empty value"
+            )));
+        }
+
+        match key {
+            "preset" => out.preset = Some(parse_preset(value)?),
+            "dict" => out.dict_size = Some(parse_u32_size(value)?),
+            "lc" => out.lc = Some(parse_u32_in_range("lc", value, 0, 8)?),
+            "lp" => out.lp = Some(parse_u32_in_range("lp", value, 0, 4)?),
+            "pb" => out.pb = Some(parse_u32_in_range("pb", value, 0, 4)?),
+            "mode" => out.mode = Some(parse_mode(value)?),
+            "nice" => out.nice_len = Some(parse_u32_in_range("nice", value, 2, 273)?),
+            "mf" => out.mf = Some(parse_mf(value)?),
+            "depth" => out.depth = Some(parse_u32("depth", value)?),
+            other => {
+                return Err(invalid_option(format!(
+                    "unknown --lzma1 option key '{other}'"
+                )))
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+/// Creates a standardized CLI error for invalid `--lzma1` option strings.
+fn invalid_option(message: String) -> Error {
+    Error::InvalidOption { message }
+}
+
+/// Parse a decimal `u32` value.
+fn parse_u32(name: &str, value: &str) -> ParseResult<u32> {
+    value.parse::<u32>().map_err(|_| {
+        invalid_option(format!(
+            "invalid --lzma1 {name} value '{value}': expected an integer"
+        ))
+    })
+}
+
+/// Parse a decimal `u32` value and validate it falls within `min..=max`.
+fn parse_u32_in_range(name: &str, value: &str, min: u32, max: u32) -> ParseResult<u32> {
+    let parsed = parse_u32(name, value)?;
+    if !(min..=max).contains(&parsed) {
+        return Err(invalid_option(format!(
+            "invalid --lzma1 {name} value '{value}': expected {min}..={max}"
+        )));
+    }
+    Ok(parsed)
+}
+
+/// Parse `mode=fast|normal`.
+fn parse_mode(value: &str) -> ParseResult<Mode> {
+    match value {
+        "fast" => Ok(Mode::Fast),
+        "normal" => Ok(Mode::Normal),
+        _ => Err(invalid_option(format!(
+            "invalid --lzma1 mode '{value}': expected fast|normal"
+        ))),
+    }
+}
+
+/// Parse `mf=hc3|hc4|bt2|bt3|bt4`.
+fn parse_mf(value: &str) -> ParseResult<MatchFinder> {
+    match value {
+        "hc3" => Ok(MatchFinder::Hc3),
+        "hc4" => Ok(MatchFinder::Hc4),
+        "bt2" => Ok(MatchFinder::Bt2),
+        "bt3" => Ok(MatchFinder::Bt3),
+        "bt4" => Ok(MatchFinder::Bt4),
+        _ => Err(invalid_option(format!(
+            "invalid --lzma1 mf '{value}': expected hc3|hc4|bt2|bt3|bt4"
+        ))),
+    }
+}
+
+/// Parse `preset=N` or `preset=Ne` where `N` is `0..=9`.
+fn parse_preset(value: &str) -> ParseResult<Compression> {
+    // Accept "N" or "Ne" (e.g. "6e") like upstream.
+    let (digits, extreme) = value
+        .strip_suffix('e')
+        .map_or((value, false), |v| (v, true));
+
+    let level: u8 = digits.parse::<u8>().map_err(|_| {
+        invalid_option(format!(
+            "invalid --lzma1 preset '{value}': expected 0..9 or 0e..9e"
+        ))
+    })?;
+    if level > 9 {
+        return Err(invalid_option(format!(
+            "invalid --lzma1 preset '{value}': expected 0..9 or 0e..9e"
+        )));
+    }
+    if extreme {
+        Ok(Compression::Extreme(level))
+    } else {
+        Compression::try_from(u32::from(level)).map_err(|_| {
+            invalid_option(format!(
+                "invalid --lzma1 preset '{value}': expected 0..9 or 0e..9e"
+            ))
+        })
+    }
+}
+
+/// Parse a `u32` byte size value, supporting `K/M/G` and `KiB/MiB/GiB` suffixes.
+fn parse_u32_size(value: &str) -> ParseResult<u32> {
+    let v = value.trim();
+    if v.is_empty() {
+        return Err(invalid_option("invalid --lzma1 dict size: empty".into()));
+    }
+
+    let (number_part, multiplier) = if let Some(rest) = v.strip_suffix("KiB") {
+        (rest, 1024_u64)
+    } else if let Some(rest) = v.strip_suffix("MiB") {
+        (rest, 1024_u64 * 1024)
+    } else if let Some(rest) = v.strip_suffix("GiB") {
+        (rest, 1024_u64 * 1024 * 1024)
+    } else if let Some(rest) = v.strip_suffix('K').or_else(|| v.strip_suffix('k')) {
+        (rest, 1024_u64)
+    } else if let Some(rest) = v.strip_suffix('M').or_else(|| v.strip_suffix('m')) {
+        (rest, 1024_u64 * 1024)
+    } else if let Some(rest) = v.strip_suffix('G').or_else(|| v.strip_suffix('g')) {
+        (rest, 1024_u64 * 1024 * 1024)
+    } else {
+        (v, 1_u64)
+    };
+
+    let num: u64 = number_part.trim().parse().map_err(|_| {
+        invalid_option(format!(
+            "invalid --lzma1 dict size '{value}': expected integer optionally suffixed with K/M/G"
+        ))
+    })?;
+
+    let bytes = num
+        .checked_mul(multiplier)
+        .ok_or_else(|| invalid_option(format!("invalid --lzma1 dict size '{value}': overflow")))?;
+
+    u32::try_from(bytes)
+        .map_err(|_| invalid_option(format!("invalid --lzma1 dict size '{value}': too large")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test parsing of a typical upstream-like `--lzma1` option string.
+    #[test]
+    fn parse_full_option_string() {
+        let opts = parse_lzma1_options(
+            "preset=6e,dict=1MiB,lc=4,lp=0,pb=2,mode=fast,nice=64,mf=hc4,depth=128",
+        )
+        .unwrap_or_else(|e| panic!("parsing must succeed in this test: {e}"));
+        assert_eq!(opts.preset, Some(Compression::Extreme(6)));
+        assert_eq!(opts.dict_size, Some(1024 * 1024));
+        assert_eq!(opts.lc, Some(4));
+        assert_eq!(opts.lp, Some(0));
+        assert_eq!(opts.pb, Some(2));
+        assert_eq!(opts.mode, Some(Mode::Fast));
+        assert_eq!(opts.nice_len, Some(64));
+        assert_eq!(opts.mf, Some(MatchFinder::Hc4));
+        assert_eq!(opts.depth, Some(128));
+    }
+
+    /// Test empty string maps to defaults (no overrides).
+    #[test]
+    fn parse_empty_is_ok() {
+        let opts =
+            parse_lzma1_options("").unwrap_or_else(|e| panic!("empty input must be ok: {e}"));
+        assert_eq!(opts, CliOptions::default());
+    }
+}

--- a/xz-cli/operations.rs
+++ b/xz-cli/operations.rs
@@ -6,6 +6,7 @@ use std::io;
 use xz_core::{
     config::EncodeFormat,
     file_info,
+    options::lzma1::Lzma1Options,
     options::{Compression, CompressionOptions, DecompressionOptions, Flags},
     pipeline::{compress, decompress},
     ratio,
@@ -14,6 +15,144 @@ use xz_core::{
 use crate::config::CliConfig;
 use crate::error::{DiagnosticCause, Error, Result};
 use crate::format::list::{self, ListOutputContext, ListSummary};
+use crate::lzma1::parse_lzma1_options;
+
+/// Resolve the output container format for compression.
+fn resolve_encode_format(config: &CliConfig) -> EncodeFormat {
+    if config.format == xz_core::config::DecodeMode::Lzma {
+        return EncodeFormat::Lzma;
+    }
+    EncodeFormat::Xz
+}
+
+/// Validate options that depend on the chosen container format.
+fn validate_format_constraints(config: &CliConfig, encode_format: EncodeFormat) -> Result<()> {
+    if encode_format == EncodeFormat::Lzma && config.check != xz_core::options::IntegrityCheck::None
+    {
+        return Err(DiagnosticCause::from(Error::InvalidOption {
+            message: "integrity checks are not supported in .lzma format".into(),
+        }));
+    }
+    Ok(())
+}
+
+/// Compute the effective compression level, applying `--extreme` when requested.
+fn resolve_compression_level(config: &CliConfig) -> Result<Compression> {
+    // Extreme is a modifier that applies to the selected preset level, not a separate level.
+    match (config.level, config.extreme) {
+        (Some(level), true) => {
+            let level_u8 = u8::try_from(level)
+                .map_err(|_| DiagnosticCause::from(Error::InvalidCompressionLevel { level }))?;
+            Ok(Compression::Extreme(level_u8))
+        }
+        (Some(level), false) => Compression::try_from(level)
+            .map_err(|_| DiagnosticCause::from(Error::InvalidCompressionLevel { level })),
+        (None, true) => {
+            let preset = Compression::default().to_preset();
+            // Invariant: `Compression::to_preset()` returns a valid xz preset level (`0..=9`).
+            let preset_u8 = u8::try_from(preset).map_err(|_| {
+                DiagnosticCause::from(Error::InvalidOption {
+                    message: format!(
+                        "internal error: default compression preset must fit into u8 (got {preset})"
+                    ),
+                })
+            })?;
+            Ok(Compression::Extreme(preset_u8))
+        }
+        (None, false) => Ok(Compression::default()),
+    }
+}
+
+/// Apply `--lzma1` overrides to compression options when encoding the `.lzma` container.
+fn apply_lzma1_overrides(
+    mut options: CompressionOptions,
+    config: &CliConfig,
+    encode_format: EncodeFormat,
+    compression_level: Compression,
+) -> Result<CompressionOptions> {
+    let Some(raw_lzma1) = config.lzma1.as_deref() else {
+        return Ok(options);
+    };
+
+    if encode_format != EncodeFormat::Lzma {
+        return Err(DiagnosticCause::from(Error::InvalidOption {
+            message: "--lzma1 is only supported with --format=lzma".into(),
+        }));
+    }
+
+    let parsed = parse_lzma1_options(raw_lzma1).map_err(DiagnosticCause::from)?;
+
+    let base_preset = parsed.preset.unwrap_or(compression_level);
+    let mut lzma1 = Lzma1Options::from_preset(base_preset).map_err(|e| {
+        DiagnosticCause::from(Error::InvalidOption {
+            message: format!("unable to apply --lzma1 preset: {e}"),
+        })
+    })?;
+
+    if let Some(dict) = parsed.dict_size {
+        lzma1 = lzma1.with_dict_size(dict);
+    }
+    if let Some(lc) = parsed.lc {
+        lzma1 = lzma1.with_lc(lc);
+    }
+    if let Some(lp) = parsed.lp {
+        lzma1 = lzma1.with_lp(lp);
+    }
+    if let Some(pb) = parsed.pb {
+        lzma1 = lzma1.with_pb(pb);
+    }
+    if let Some(mode) = parsed.mode {
+        lzma1 = lzma1.with_mode(mode);
+    }
+    if let Some(nice) = parsed.nice_len {
+        lzma1 = lzma1.with_nice_len(nice);
+    }
+    if let Some(mf) = parsed.mf {
+        lzma1 = lzma1.with_match_finder(mf);
+    }
+    if let Some(depth) = parsed.depth {
+        lzma1 = lzma1.with_depth(depth);
+    }
+
+    options = options.with_lzma1_options(Some(lzma1));
+    Ok(options)
+}
+
+/// Apply `--threads` to compression options when supported by the container format.
+fn apply_threads_for_compression(
+    mut options: CompressionOptions,
+    config: &CliConfig,
+    encode_format: EncodeFormat,
+) -> Result<CompressionOptions> {
+    let Some(threads) = config.threads else {
+        return Ok(options);
+    };
+
+    if encode_format == EncodeFormat::Lzma && threads > 1 {
+        return Err(DiagnosticCause::from(Error::InvalidOption {
+            message: "threading is not supported in .lzma format".into(),
+        }));
+    }
+
+    let thread_count = u32::try_from(threads)
+        .map_err(|_| DiagnosticCause::from(Error::InvalidThreadCount { count: threads }))?;
+    options = options.with_threads(xz_core::Threading::Exact(thread_count));
+    Ok(options)
+}
+
+/// Emit verbose/robot output for a completed compression operation.
+fn emit_compress_summary(config: &CliConfig, bytes_read: u64, bytes_written: u64) {
+    if !(config.verbose || config.robot) {
+        return;
+    }
+
+    let ratio = ratio(bytes_written, bytes_read);
+    if config.robot {
+        println!("{bytes_read} {bytes_written} {ratio:.1}");
+    } else {
+        eprintln!("Compressed {bytes_read} bytes to {bytes_written} bytes ({ratio:.1}% ratio)");
+    }
+}
 
 /// Compresses data from an input reader to an output writer.
 ///
@@ -48,59 +187,17 @@ pub fn compress_file(
     mut output: impl io::Write,
     config: &CliConfig,
 ) -> Result<()> {
-    let mut options = CompressionOptions::default();
+    let encode_format = resolve_encode_format(config);
+    validate_format_constraints(config, encode_format)?;
 
-    let encode_format = match config.format {
-        xz_core::config::DecodeMode::Lzma => EncodeFormat::Lzma,
-        _ => EncodeFormat::Xz,
-    };
-    options = options.with_format(encode_format);
+    let compression_level = resolve_compression_level(config)?;
 
-    if encode_format == EncodeFormat::Lzma && config.check != xz_core::options::IntegrityCheck::None
-    {
-        return Err(DiagnosticCause::from(Error::InvalidOption {
-            message: "integrity checks are not supported in .lzma format".into(),
-        }));
-    }
-    options = options.with_check(config.check);
-
-    // Determine the compression level and apply extreme mode if enabled
-    //
-    // Extreme is a modifier that applies to the selected preset level,
-    // not a separate level.
-    let compression_level = match (config.level, config.extreme) {
-        (Some(level), true) => {
-            let level_conv = u8::try_from(level)
-                .map_err(|_| DiagnosticCause::from(Error::InvalidCompressionLevel { level }))?;
-            if level_conv > 9 {
-                return Err(DiagnosticCause::from(Error::InvalidCompressionLevel {
-                    level,
-                }));
-            }
-            Compression::Extreme(level_conv)
-        }
-        (Some(level), false) => Compression::try_from(level)
-            .map_err(|_| DiagnosticCause::from(Error::InvalidCompressionLevel { level }))?,
-        (None, true) => {
-            let level = Compression::default();
-            Compression::Extreme(u8::try_from(level.to_preset()).unwrap())
-        }
-        (None, false) => Compression::default(),
-    };
-
-    options = options.with_level(compression_level);
-
-    // Set thread count if specified
-    if let Some(threads) = config.threads {
-        if encode_format == EncodeFormat::Lzma && threads > 1 {
-            return Err(DiagnosticCause::from(Error::InvalidOption {
-                message: "threading is not supported in .lzma format".into(),
-            }));
-        }
-        let thread_count = u32::try_from(threads)
-            .map_err(|_| DiagnosticCause::from(Error::InvalidThreadCount { count: threads }))?;
-        options = options.with_threads(xz_core::Threading::Exact(thread_count));
-    }
+    let options = CompressionOptions::default()
+        .with_format(encode_format)
+        .with_check(config.check)
+        .with_level(compression_level);
+    let options = apply_lzma1_overrides(options, config, encode_format, compression_level)?;
+    let options = apply_threads_for_compression(options, config, encode_format)?;
 
     // Perform compression and handle errors
     let summary = compress(&mut input, &mut output, &options).map_err(|e| {
@@ -110,24 +207,7 @@ pub fn compress_file(
         })
     })?;
 
-    // Print output if verbose or robot mode is enabled
-    if config.verbose || config.robot {
-        let ratio = ratio(summary.bytes_written, summary.bytes_read);
-
-        if config.robot {
-            // Machine-readable output for robot mode
-            println!(
-                "{} {} {:.1}",
-                summary.bytes_read, summary.bytes_written, ratio
-            );
-        } else {
-            // Human-readable output for verbose mode
-            eprintln!(
-                "Compressed {} bytes to {} bytes ({:.1}% ratio)",
-                summary.bytes_read, summary.bytes_written, ratio
-            );
-        }
-    }
+    emit_compress_summary(config, summary.bytes_read, summary.bytes_written);
 
     Ok(())
 }

--- a/xz-cli/process.rs
+++ b/xz-cli/process.rs
@@ -108,10 +108,17 @@ pub fn process_file(input_path: &str, config: &CliConfig) -> Result<()> {
     {
         None
     } else {
+        let default_extension = match (config.mode, config.format) {
+            (OperationMode::Compress, xz_core::config::DecodeMode::Lzma) => {
+                crate::config::LZMA_EXTENSION
+            }
+            _ => crate::config::XZ_EXTENSION,
+        };
         Some(generate_output_filename(
             &input_path_buf,
             config.mode,
             config.suffix.as_deref(),
+            default_extension,
             config.force,
         )?)
     };

--- a/xz-cli/process.rs
+++ b/xz-cli/process.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::path::PathBuf;
 
 use crate::config::{CliConfig, OperationMode};
-use crate::error::{DiagnosticCause, Error, ExitStatus, Report, Result};
+use crate::error::{DiagnosticCause, Error, ExitStatus, IoErrorNoCode, Report, Result};
 use crate::format::list::{print_list_totals, ListOutputContext, ListSummary};
 use crate::io::{
     generate_output_filename, open_input, open_output, open_output_file, SparseFileWriter,
@@ -39,8 +39,7 @@ pub fn cleanup_input_file(input_path: &str, config: &CliConfig) -> Result<()> {
     if !config.keep && !is_stdin && !config.stdout {
         std::fs::remove_file(input_path).map_err(|source| {
             DiagnosticCause::from(Error::RemoveFile {
-                path: input_path.to_string(),
-                source,
+                source: IoErrorNoCode::new(source),
             })
         })?;
 

--- a/xz-cli/tests.rs
+++ b/xz-cli/tests.rs
@@ -87,12 +87,14 @@ fn has_compression_extension_no_extension() {
 fn generate_output_filename_compress_basic() {
     let input = Path::new("test.txt");
     let output =
-        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false).unwrap();
+        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false)
+            .unwrap();
     assert_eq!(output, PathBuf::from("test.txt.xz"));
 
     let input = Path::new("test");
     let output =
-        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false).unwrap();
+        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false)
+            .unwrap();
     assert_eq!(output, PathBuf::from("test.xz"));
 }
 
@@ -101,7 +103,8 @@ fn generate_output_filename_compress_basic() {
 fn generate_output_filename_compress_double_extension() {
     let input = Path::new("file.tar");
     let output =
-        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false).unwrap();
+        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false)
+            .unwrap();
     assert_eq!(output, PathBuf::from("file.tar.xz"));
 }
 
@@ -110,7 +113,8 @@ fn generate_output_filename_compress_double_extension() {
 fn generate_output_filename_compress_with_path() {
     let input = Path::new("/path/to/file.txt");
     let output =
-        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false).unwrap();
+        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false)
+            .unwrap();
     assert_eq!(output, PathBuf::from("/path/to/file.txt.xz"));
 }
 
@@ -184,15 +188,25 @@ fn generate_output_filename_decompress_no_extension() {
 #[test]
 fn generate_output_filename_compress_custom_suffix() {
     let input = Path::new("test.txt");
-    let output =
-        generate_output_filename(input, OperationMode::Compress, Some("myext"), XZ_EXTENSION, false)
-            .unwrap();
+    let output = generate_output_filename(
+        input,
+        OperationMode::Compress,
+        Some("myext"),
+        XZ_EXTENSION,
+        false,
+    )
+    .unwrap();
     assert_eq!(output, PathBuf::from("test.txt.myext"));
 
     let input = Path::new("file");
-    let output =
-        generate_output_filename(input, OperationMode::Compress, Some("gz"), XZ_EXTENSION, false)
-            .unwrap();
+    let output = generate_output_filename(
+        input,
+        OperationMode::Compress,
+        Some("gz"),
+        XZ_EXTENSION,
+        false,
+    )
+    .unwrap();
     assert_eq!(output, PathBuf::from("file.gz"));
 }
 
@@ -200,9 +214,14 @@ fn generate_output_filename_compress_custom_suffix() {
 #[test]
 fn generate_output_filename_compress_custom_suffix_with_dot() {
     let input = Path::new("test.txt");
-    let output =
-        generate_output_filename(input, OperationMode::Compress, Some(".custom"), XZ_EXTENSION, false)
-            .unwrap();
+    let output = generate_output_filename(
+        input,
+        OperationMode::Compress,
+        Some(".custom"),
+        XZ_EXTENSION,
+        false,
+    )
+    .unwrap();
     // Leading dot should be stripped, so we get .custom not ..custom
     assert_eq!(output, PathBuf::from("test.txt.custom"));
 }
@@ -211,15 +230,25 @@ fn generate_output_filename_compress_custom_suffix_with_dot() {
 #[test]
 fn generate_output_filename_decompress_custom_suffix() {
     let input = Path::new("test.txt.myext");
-    let output =
-        generate_output_filename(input, OperationMode::Decompress, Some("myext"), XZ_EXTENSION, false)
-            .unwrap();
+    let output = generate_output_filename(
+        input,
+        OperationMode::Decompress,
+        Some("myext"),
+        XZ_EXTENSION,
+        false,
+    )
+    .unwrap();
     assert_eq!(output, PathBuf::from("test.txt"));
 
     let input = Path::new("file.custom");
-    let output =
-        generate_output_filename(input, OperationMode::Decompress, Some(".custom"), XZ_EXTENSION, false)
-            .unwrap();
+    let output = generate_output_filename(
+        input,
+        OperationMode::Decompress,
+        Some(".custom"),
+        XZ_EXTENSION,
+        false,
+    )
+    .unwrap();
     assert_eq!(output, PathBuf::from("file"));
 }
 
@@ -227,8 +256,13 @@ fn generate_output_filename_decompress_custom_suffix() {
 #[test]
 fn generate_output_filename_decompress_custom_suffix_mismatch() {
     let input = Path::new("test.txt.xz");
-    let result =
-        generate_output_filename(input, OperationMode::Decompress, Some("myext"), XZ_EXTENSION, false);
+    let result = generate_output_filename(
+        input,
+        OperationMode::Decompress,
+        Some("myext"),
+        XZ_EXTENSION,
+        false,
+    );
     assert!(result.is_err());
     assert!(matches!(
         result,
@@ -249,8 +283,13 @@ fn generate_output_filename_compress_already_has_suffix() {
     ));
 
     let input = Path::new("test.custom");
-    let result =
-        generate_output_filename(input, OperationMode::Compress, Some("custom"), XZ_EXTENSION, false);
+    let result = generate_output_filename(
+        input,
+        OperationMode::Compress,
+        Some("custom"),
+        XZ_EXTENSION,
+        false,
+    );
     assert!(result.is_err());
     assert!(matches!(
         result,
@@ -258,8 +297,13 @@ fn generate_output_filename_compress_already_has_suffix() {
     ));
 
     let input = Path::new("test.myext");
-    let result =
-        generate_output_filename(input, OperationMode::Compress, Some(".myext"), XZ_EXTENSION, false);
+    let result = generate_output_filename(
+        input,
+        OperationMode::Compress,
+        Some(".myext"),
+        XZ_EXTENSION,
+        false,
+    );
     assert!(result.is_err());
     assert!(matches!(
         result,
@@ -276,9 +320,14 @@ fn generate_output_filename_compress_force_allows_suffix() {
     assert_eq!(output, PathBuf::from("test.txt.xz.xz"));
 
     let input = Path::new("test.custom");
-    let output =
-        generate_output_filename(input, OperationMode::Compress, Some("custom"), XZ_EXTENSION, true)
-            .unwrap();
+    let output = generate_output_filename(
+        input,
+        OperationMode::Compress,
+        Some("custom"),
+        XZ_EXTENSION,
+        true,
+    )
+    .unwrap();
     assert_eq!(output, PathBuf::from("test.custom.custom"));
 }
 

--- a/xz-cli/tests.rs
+++ b/xz-cli/tests.rs
@@ -86,11 +86,13 @@ fn has_compression_extension_no_extension() {
 #[test]
 fn generate_output_filename_compress_basic() {
     let input = Path::new("test.txt");
-    let output = generate_output_filename(input, OperationMode::Compress, None, false).unwrap();
+    let output =
+        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false).unwrap();
     assert_eq!(output, PathBuf::from("test.txt.xz"));
 
     let input = Path::new("test");
-    let output = generate_output_filename(input, OperationMode::Compress, None, false).unwrap();
+    let output =
+        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false).unwrap();
     assert_eq!(output, PathBuf::from("test.xz"));
 }
 
@@ -98,7 +100,8 @@ fn generate_output_filename_compress_basic() {
 #[test]
 fn generate_output_filename_compress_double_extension() {
     let input = Path::new("file.tar");
-    let output = generate_output_filename(input, OperationMode::Compress, None, false).unwrap();
+    let output =
+        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false).unwrap();
     assert_eq!(output, PathBuf::from("file.tar.xz"));
 }
 
@@ -106,7 +109,8 @@ fn generate_output_filename_compress_double_extension() {
 #[test]
 fn generate_output_filename_compress_with_path() {
     let input = Path::new("/path/to/file.txt");
-    let output = generate_output_filename(input, OperationMode::Compress, None, false).unwrap();
+    let output =
+        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false).unwrap();
     assert_eq!(output, PathBuf::from("/path/to/file.txt.xz"));
 }
 
@@ -114,11 +118,15 @@ fn generate_output_filename_compress_with_path() {
 #[test]
 fn generate_output_filename_decompress_basic() {
     let input = Path::new("test.txt.xz");
-    let output = generate_output_filename(input, OperationMode::Decompress, None, false).unwrap();
+    let output =
+        generate_output_filename(input, OperationMode::Decompress, None, XZ_EXTENSION, false)
+            .unwrap();
     assert_eq!(output, PathBuf::from("test.txt"));
 
     let input = Path::new("test.lzma");
-    let output = generate_output_filename(input, OperationMode::Decompress, None, false).unwrap();
+    let output =
+        generate_output_filename(input, OperationMode::Decompress, None, XZ_EXTENSION, false)
+            .unwrap();
     assert_eq!(output, PathBuf::from("test"));
 }
 
@@ -126,7 +134,9 @@ fn generate_output_filename_decompress_basic() {
 #[test]
 fn generate_output_filename_decompress_with_path() {
     let input = Path::new("/path/to/archive.xz");
-    let output = generate_output_filename(input, OperationMode::Decompress, None, false).unwrap();
+    let output =
+        generate_output_filename(input, OperationMode::Decompress, None, XZ_EXTENSION, false)
+            .unwrap();
     assert_eq!(output, PathBuf::from("/path/to/archive"));
 }
 
@@ -134,7 +144,8 @@ fn generate_output_filename_decompress_with_path() {
 #[test]
 fn generate_output_filename_cat_mode() {
     let input = Path::new("test.txt.xz");
-    let output = generate_output_filename(input, OperationMode::Cat, None, false).unwrap();
+    let output =
+        generate_output_filename(input, OperationMode::Cat, None, XZ_EXTENSION, false).unwrap();
     assert_eq!(output, PathBuf::from("test.txt"));
 }
 
@@ -142,7 +153,8 @@ fn generate_output_filename_cat_mode() {
 #[test]
 fn generate_output_filename_test_mode() {
     let input = Path::new("test.xz");
-    let output = generate_output_filename(input, OperationMode::Test, None, false).unwrap();
+    let output =
+        generate_output_filename(input, OperationMode::Test, None, XZ_EXTENSION, false).unwrap();
     assert_eq!(output, PathBuf::new());
 }
 
@@ -150,7 +162,8 @@ fn generate_output_filename_test_mode() {
 #[test]
 fn generate_output_filename_decompress_invalid_extension() {
     let input = Path::new("test.txt");
-    let result = generate_output_filename(input, OperationMode::Decompress, None, false);
+    let result =
+        generate_output_filename(input, OperationMode::Decompress, None, XZ_EXTENSION, false);
     assert!(result.is_err());
     assert!(matches!(
         result.unwrap_err(),
@@ -162,7 +175,8 @@ fn generate_output_filename_decompress_invalid_extension() {
 #[test]
 fn generate_output_filename_decompress_no_extension() {
     let input = Path::new("test");
-    let result = generate_output_filename(input, OperationMode::Decompress, None, false);
+    let result =
+        generate_output_filename(input, OperationMode::Decompress, None, XZ_EXTENSION, false);
     assert!(result.is_err());
 }
 
@@ -171,12 +185,14 @@ fn generate_output_filename_decompress_no_extension() {
 fn generate_output_filename_compress_custom_suffix() {
     let input = Path::new("test.txt");
     let output =
-        generate_output_filename(input, OperationMode::Compress, Some("myext"), false).unwrap();
+        generate_output_filename(input, OperationMode::Compress, Some("myext"), XZ_EXTENSION, false)
+            .unwrap();
     assert_eq!(output, PathBuf::from("test.txt.myext"));
 
     let input = Path::new("file");
     let output =
-        generate_output_filename(input, OperationMode::Compress, Some("gz"), false).unwrap();
+        generate_output_filename(input, OperationMode::Compress, Some("gz"), XZ_EXTENSION, false)
+            .unwrap();
     assert_eq!(output, PathBuf::from("file.gz"));
 }
 
@@ -185,7 +201,8 @@ fn generate_output_filename_compress_custom_suffix() {
 fn generate_output_filename_compress_custom_suffix_with_dot() {
     let input = Path::new("test.txt");
     let output =
-        generate_output_filename(input, OperationMode::Compress, Some(".custom"), false).unwrap();
+        generate_output_filename(input, OperationMode::Compress, Some(".custom"), XZ_EXTENSION, false)
+            .unwrap();
     // Leading dot should be stripped, so we get .custom not ..custom
     assert_eq!(output, PathBuf::from("test.txt.custom"));
 }
@@ -195,12 +212,14 @@ fn generate_output_filename_compress_custom_suffix_with_dot() {
 fn generate_output_filename_decompress_custom_suffix() {
     let input = Path::new("test.txt.myext");
     let output =
-        generate_output_filename(input, OperationMode::Decompress, Some("myext"), false).unwrap();
+        generate_output_filename(input, OperationMode::Decompress, Some("myext"), XZ_EXTENSION, false)
+            .unwrap();
     assert_eq!(output, PathBuf::from("test.txt"));
 
     let input = Path::new("file.custom");
     let output =
-        generate_output_filename(input, OperationMode::Decompress, Some(".custom"), false).unwrap();
+        generate_output_filename(input, OperationMode::Decompress, Some(".custom"), XZ_EXTENSION, false)
+            .unwrap();
     assert_eq!(output, PathBuf::from("file"));
 }
 
@@ -208,7 +227,8 @@ fn generate_output_filename_decompress_custom_suffix() {
 #[test]
 fn generate_output_filename_decompress_custom_suffix_mismatch() {
     let input = Path::new("test.txt.xz");
-    let result = generate_output_filename(input, OperationMode::Decompress, Some("myext"), false);
+    let result =
+        generate_output_filename(input, OperationMode::Decompress, Some("myext"), XZ_EXTENSION, false);
     assert!(result.is_err());
     assert!(matches!(
         result,
@@ -220,7 +240,8 @@ fn generate_output_filename_decompress_custom_suffix_mismatch() {
 #[test]
 fn generate_output_filename_compress_already_has_suffix() {
     let input = Path::new("test.txt.xz");
-    let result = generate_output_filename(input, OperationMode::Compress, None, false);
+    let result =
+        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false);
     assert!(result.is_err());
     assert!(matches!(
         result,
@@ -228,7 +249,8 @@ fn generate_output_filename_compress_already_has_suffix() {
     ));
 
     let input = Path::new("test.custom");
-    let result = generate_output_filename(input, OperationMode::Compress, Some("custom"), false);
+    let result =
+        generate_output_filename(input, OperationMode::Compress, Some("custom"), XZ_EXTENSION, false);
     assert!(result.is_err());
     assert!(matches!(
         result,
@@ -236,7 +258,8 @@ fn generate_output_filename_compress_already_has_suffix() {
     ));
 
     let input = Path::new("test.myext");
-    let result = generate_output_filename(input, OperationMode::Compress, Some(".myext"), false);
+    let result =
+        generate_output_filename(input, OperationMode::Compress, Some(".myext"), XZ_EXTENSION, false);
     assert!(result.is_err());
     assert!(matches!(
         result,
@@ -248,12 +271,14 @@ fn generate_output_filename_compress_already_has_suffix() {
 #[test]
 fn generate_output_filename_compress_force_allows_suffix() {
     let input = Path::new("test.txt.xz");
-    let output = generate_output_filename(input, OperationMode::Compress, None, true).unwrap();
+    let output =
+        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, true).unwrap();
     assert_eq!(output, PathBuf::from("test.txt.xz.xz"));
 
     let input = Path::new("test.custom");
     let output =
-        generate_output_filename(input, OperationMode::Compress, Some("custom"), true).unwrap();
+        generate_output_filename(input, OperationMode::Compress, Some("custom"), XZ_EXTENSION, true)
+            .unwrap();
     assert_eq!(output, PathBuf::from("test.custom.custom"));
 }
 

--- a/xz-cli/tests/test_cli/lzcat/basic.rs
+++ b/xz-cli/tests/test_cli/lzcat/basic.rs
@@ -1,8 +1,8 @@
 use crate::add_test;
 use crate::common::{Fixture, SAMPLE_TEXT};
 
-// Test basic compression and decompression.
-add_test!(compress_decompress, async {
+// Test basic lzcat functionality.
+add_test!(basic_decompress, async {
     const FILE_NAME: &str = "test.txt";
 
     let data = SAMPLE_TEXT.as_bytes();
@@ -11,15 +11,12 @@ add_test!(compress_decompress, async {
     let file_path = fixture.path(FILE_NAME);
     let lzma_path = fixture.lzma_path(FILE_NAME);
 
-    // Compress to .lzma
+    // Create .lzma file using our lzma.
     let output = fixture.run_cargo("lzma", &["-k", &file_path]).await;
     assert!(output.status.success(), "lzma failed: {}", output.stderr);
-    assert!(fixture.file_exists("test.txt.lzma"));
 
-    fixture.remove_file(FILE_NAME);
-
-    // Decompress back
-    let output = fixture.run_cargo("unlzma", &[&lzma_path]).await;
-    assert!(output.status.success(), "unlzma failed: {}", output.stderr);
-    fixture.assert_files(&[FILE_NAME], &[data]);
+    // lzcat should write decompressed bytes to stdout.
+    let output = fixture.run_cargo("lzcat", &[&lzma_path]).await;
+    assert!(output.status.success(), "lzcat failed: {}", output.stderr);
+    assert!(output.stdout_raw == data);
 });

--- a/xz-cli/tests/test_cli/lzcat/cli_options.rs
+++ b/xz-cli/tests/test_cli/lzcat/cli_options.rs
@@ -1,0 +1,22 @@
+use crate::add_test;
+use crate::common::{Fixture, SAMPLE_TEXT};
+
+// Test that `--threads`/`-T` is accepted for compatibility but ignored for `.lzma` files.
+add_test!(threads_ignored, async {
+    const FILE_NAME: &str = "threads.txt";
+
+    let data = SAMPLE_TEXT.as_bytes();
+    let mut fixture = Fixture::with_file(FILE_NAME, data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let lzma_path = fixture.lzma_path(FILE_NAME);
+
+    // Create .lzma file.
+    let output = fixture.run_cargo("lzma", &["-k", &file_path]).await;
+    assert!(output.status.success(), "lzma failed: {}", output.stderr);
+
+    // `--threads` is accepted for CLI compatibility but ignored for `.lzma`.
+    let output = fixture.run_cargo("lzcat", &["-T", "4", &lzma_path]).await;
+    assert!(output.status.success(), "lzcat failed: {}", output.stderr);
+    assert!(output.stdout_raw == data);
+});

--- a/xz-cli/tests/test_cli/lzcat/edge_cases.rs
+++ b/xz-cli/tests/test_cli/lzcat/edge_cases.rs
@@ -1,0 +1,45 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+
+use crate::add_test;
+use crate::common::{Fixture, SAMPLE_TEXT};
+
+// Test that lzcat fails with trailing garbage by default and succeeds with `--single-stream`.
+add_test!(trailing_garbage, async {
+    const FILE_NAME: &str = "garbage.txt";
+
+    let data = SAMPLE_TEXT.as_bytes();
+    let mut fixture = Fixture::with_file(FILE_NAME, data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let lzma_path = fixture.lzma_path(FILE_NAME);
+
+    // Produce a valid .lzma file first.
+    let out = fixture
+        .run_cargo("lzma", &["--lzma1", "preset=6", "-k", &file_path])
+        .await;
+    assert!(out.status.success(), "lzma failed: {}", out.stderr);
+
+    // Append trailing garbage.
+    let mut f = OpenOptions::new()
+        .append(true)
+        .open(&lzma_path)
+        .expect("open .lzma for append");
+    f.write_all(b"TRAILING_GARBAGE").expect("append garbage");
+    drop(f);
+
+    // Strict by default: should fail.
+    let out = fixture.run_cargo("lzcat", &[&lzma_path]).await;
+    assert!(!out.status.success(), "lzcat unexpectedly succeeded");
+
+    // Tolerant with --single-stream: should ignore the tail and succeed.
+    let out = fixture
+        .run_cargo("lzcat", &["--single-stream", &lzma_path])
+        .await;
+    assert!(
+        out.status.success(),
+        "lzcat --single-stream failed: {}",
+        out.stderr
+    );
+    assert!(out.stdout_raw == data);
+});

--- a/xz-cli/tests/test_cli/lzcat/mod.rs
+++ b/xz-cli/tests/test_cli/lzcat/mod.rs
@@ -1,0 +1,3 @@
+// lzcat is covered by the lzma integration tests.
+
+

--- a/xz-cli/tests/test_cli/lzcat/mod.rs
+++ b/xz-cli/tests/test_cli/lzcat/mod.rs
@@ -1,1 +1,3 @@
-// lzcat is covered by the lzma integration tests.
+mod basic;
+mod cli_options;
+mod edge_cases;

--- a/xz-cli/tests/test_cli/lzcat/mod.rs
+++ b/xz-cli/tests/test_cli/lzcat/mod.rs
@@ -1,3 +1,1 @@
 // lzcat is covered by the lzma integration tests.
-
-

--- a/xz-cli/tests/test_cli/lzma/basic.rs
+++ b/xz-cli/tests/test_cli/lzma/basic.rs
@@ -1,0 +1,45 @@
+use crate::add_test;
+use crate::common::{Fixture, SAMPLE_TEXT};
+
+add_test!(basic_compress_decompress_roundtrip, async {
+    const FILE_NAME: &str = "test.txt";
+
+    let data = SAMPLE_TEXT.as_bytes();
+    let mut fixture = Fixture::with_file(FILE_NAME, data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let lzma_path = fixture.lzma_path(FILE_NAME);
+
+    // Compress to .lzma
+    let output = fixture.run_cargo("lzma", &["-k", &file_path]).await;
+    assert!(output.status.success(), "lzma failed: {}", output.stderr);
+    assert!(fixture.file_exists("test.txt.lzma"));
+
+    fixture.remove_file(FILE_NAME);
+
+    // Decompress back
+    let output = fixture.run_cargo("unlzma", &[&lzma_path]).await;
+    assert!(output.status.success(), "unlzma failed: {}", output.stderr);
+    fixture.assert_files(&[FILE_NAME], &[data]);
+});
+
+add_test!(lzcat_outputs_plaintext_to_stdout, async {
+    const FILE_NAME: &str = "test.txt";
+
+    let data = SAMPLE_TEXT.as_bytes();
+    let mut fixture = Fixture::with_file(FILE_NAME, data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let lzma_path = fixture.lzma_path(FILE_NAME);
+
+    // Create .lzma file
+    let output = fixture.run_cargo("lzma", &["-k", &file_path]).await;
+    assert!(output.status.success(), "lzma failed: {}", output.stderr);
+
+    // lzcat should write decompressed bytes to stdout
+    let output = fixture.run_cargo("lzcat", &[&lzma_path]).await;
+    assert!(output.status.success(), "lzcat failed: {}", output.stderr);
+    assert!(output.stdout_raw == data);
+});
+
+

--- a/xz-cli/tests/test_cli/lzma/interop.rs
+++ b/xz-cli/tests/test_cli/lzma/interop.rs
@@ -1,0 +1,60 @@
+use crate::add_test;
+use crate::common::{Fixture, SAMPLE_TEXT};
+
+// Test system xz (format=lzma) -> our unlzma.
+add_test!(system_xz_lzma_to_our_unlzma, async {
+    const FILE_NAME: &str = "test.txt";
+
+    let data = SAMPLE_TEXT.as_bytes();
+    let mut fixture = Fixture::with_file(FILE_NAME, data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let lzma_path = fixture.lzma_path(FILE_NAME);
+
+    let Some(system_out) = fixture
+        .run_system("xz", &["--format=lzma", "-k", &file_path])
+        .await
+    else {
+        return;
+    };
+    assert!(
+        system_out.status.success(),
+        "system xz failed: {}",
+        system_out.stderr
+    );
+
+    fixture.remove_file(FILE_NAME);
+
+    let output = fixture.run_cargo("unlzma", &[&lzma_path]).await;
+    assert!(output.status.success(), "unlzma failed: {}", output.stderr);
+    fixture.assert_files(&[FILE_NAME], &[data]);
+});
+
+// Test our xz (format=lzma) -> system xz -d.
+add_test!(our_xz_lzma_to_system_xz, async {
+    const FILE_NAME: &str = "test.txt";
+
+    let data = SAMPLE_TEXT.as_bytes();
+    let mut fixture = Fixture::with_file(FILE_NAME, data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let lzma_path = fixture.lzma_path(FILE_NAME);
+
+    let output = fixture
+        .run_cargo("xz", &["--format=lzma", "-k", &file_path])
+        .await;
+    assert!(output.status.success(), "our xz failed: {}", output.stderr);
+
+    fixture.remove_file(FILE_NAME);
+
+    let Some(system_out) = fixture.run_system("xz", &["-d", &lzma_path]).await else {
+        return;
+    };
+    assert!(
+        system_out.status.success(),
+        "system xz -d failed: {}",
+        system_out.stderr
+    );
+});
+
+

--- a/xz-cli/tests/test_cli/lzma/interop.rs
+++ b/xz-cli/tests/test_cli/lzma/interop.rs
@@ -56,5 +56,3 @@ add_test!(our_xz_lzma_to_system_xz, async {
         system_out.stderr
     );
 });
-
-

--- a/xz-cli/tests/test_cli/lzma/mod.rs
+++ b/xz-cli/tests/test_cli/lzma/mod.rs
@@ -1,4 +1,3 @@
 mod basic;
 mod cli_options;
-mod interop;
 mod vectors;

--- a/xz-cli/tests/test_cli/lzma/mod.rs
+++ b/xz-cli/tests/test_cli/lzma/mod.rs
@@ -1,4 +1,4 @@
 mod basic;
+mod cli_options;
 mod interop;
-
-
+mod vectors;

--- a/xz-cli/tests/test_cli/lzma/mod.rs
+++ b/xz-cli/tests/test_cli/lzma/mod.rs
@@ -1,0 +1,4 @@
+mod basic;
+mod interop;
+
+

--- a/xz-cli/tests/test_cli/lzma/vectors.rs
+++ b/xz-cli/tests/test_cli/lzma/vectors.rs
@@ -1,0 +1,108 @@
+use std::path::Path;
+
+use crate::add_test;
+use crate::common::Fixture;
+
+fn write_file(path: &Path, bytes: &[u8]) {
+    std::fs::write(path, bytes).unwrap();
+}
+
+add_test!(lzma_vectors_good_decode, async {
+    let mut fixture = Fixture::with_file("dummy.txt", b"dummy");
+    let root = fixture.root_dir_path().to_path_buf();
+
+    let good_vectors: &[(&str, &[u8])] = &[
+        (
+            "good-known_size-with_eopm.lzma",
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../lzma-safe/liblzma-sys/xz/tests/files/good-known_size-with_eopm.lzma"
+            )),
+        ),
+        (
+            "good-known_size-without_eopm.lzma",
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../lzma-safe/liblzma-sys/xz/tests/files/good-known_size-without_eopm.lzma"
+            )),
+        ),
+        (
+            "good-unknown_size-with_eopm.lzma",
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../lzma-safe/liblzma-sys/xz/tests/files/good-unknown_size-with_eopm.lzma"
+            )),
+        ),
+    ];
+
+    for (name, bytes) in good_vectors {
+        let path = root.join(name);
+        write_file(&path, bytes);
+
+        let output = fixture
+            .run_cargo("unlzma", &["-c", path.to_string_lossy().as_ref()])
+            .await;
+        assert!(
+            output.status.success(),
+            "failed for {name}: {}",
+            output.stderr
+        );
+        assert!(
+            !output.stdout_raw.is_empty(),
+            "expected non-empty output for {name}"
+        );
+    }
+});
+
+add_test!(lzma_vectors_bad_rejected, async {
+    let mut fixture = Fixture::with_file("dummy.txt", b"dummy");
+    let root = fixture.root_dir_path().to_path_buf();
+
+    let bad_vectors: &[(&str, &[u8])] = &[
+        (
+            "bad-unknown_size-without_eopm.lzma",
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../lzma-safe/liblzma-sys/xz/tests/files/bad-unknown_size-without_eopm.lzma"
+            )),
+        ),
+        (
+            "bad-too_big_size-with_eopm.lzma",
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../lzma-safe/liblzma-sys/xz/tests/files/bad-too_big_size-with_eopm.lzma"
+            )),
+        ),
+        (
+            "bad-too_small_size-without_eopm-1.lzma",
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../lzma-safe/liblzma-sys/xz/tests/files/bad-too_small_size-without_eopm-1.lzma"
+            )),
+        ),
+        (
+            "bad-too_small_size-without_eopm-2.lzma",
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../lzma-safe/liblzma-sys/xz/tests/files/bad-too_small_size-without_eopm-2.lzma"
+            )),
+        ),
+        (
+            "bad-too_small_size-without_eopm-3.lzma",
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../lzma-safe/liblzma-sys/xz/tests/files/bad-too_small_size-without_eopm-3.lzma"
+            )),
+        ),
+    ];
+
+    for (name, bytes) in bad_vectors {
+        let path = root.join(name);
+        write_file(&path, bytes);
+
+        let output = fixture
+            .run_cargo("unlzma", &["-c", path.to_string_lossy().as_ref()])
+            .await;
+        assert!(!output.status.success(), "expected failure for {name}");
+    }
+});

--- a/xz-cli/tests/test_cli/lzma/vectors.rs
+++ b/xz-cli/tests/test_cli/lzma/vectors.rs
@@ -7,7 +7,8 @@ fn write_file(path: &Path, bytes: &[u8]) {
     std::fs::write(path, bytes).unwrap();
 }
 
-add_test!(lzma_vectors_good_decode, async {
+// Test good `.lzma` vectors.
+add_test!(good_decode, async {
     let mut fixture = Fixture::with_file("dummy.txt", b"dummy");
     let root = fixture.root_dir_path().to_path_buf();
 
@@ -54,7 +55,8 @@ add_test!(lzma_vectors_good_decode, async {
     }
 });
 
-add_test!(lzma_vectors_bad_rejected, async {
+// Test bad `.lzma` vectors.
+add_test!(bad_rejected, async {
     let mut fixture = Fixture::with_file("dummy.txt", b"dummy");
     let root = fixture.root_dir_path().to_path_buf();
 

--- a/xz-cli/tests/test_cli/main.rs
+++ b/xz-cli/tests/test_cli/main.rs
@@ -1,4 +1,7 @@
 pub mod common;
+mod lzcat;
+mod lzma;
+mod unlzma;
 mod unxz;
 mod xz;
 mod xzcat;

--- a/xz-cli/tests/test_cli/unlzma/basic.rs
+++ b/xz-cli/tests/test_cli/unlzma/basic.rs
@@ -1,8 +1,8 @@
 use crate::add_test;
 use crate::common::{Fixture, SAMPLE_TEXT};
 
-// Test basic compression and decompression.
-add_test!(compress_decompress, async {
+// Test basic unlzma functionality.
+add_test!(basic_decompress, async {
     const FILE_NAME: &str = "test.txt";
 
     let data = SAMPLE_TEXT.as_bytes();
@@ -11,14 +11,13 @@ add_test!(compress_decompress, async {
     let file_path = fixture.path(FILE_NAME);
     let lzma_path = fixture.lzma_path(FILE_NAME);
 
-    // Compress to .lzma
+    // Create .lzma file.
     let output = fixture.run_cargo("lzma", &["-k", &file_path]).await;
     assert!(output.status.success(), "lzma failed: {}", output.stderr);
-    assert!(fixture.file_exists("test.txt.lzma"));
 
     fixture.remove_file(FILE_NAME);
 
-    // Decompress back
+    // Decompress back using unlzma.
     let output = fixture.run_cargo("unlzma", &[&lzma_path]).await;
     assert!(output.status.success(), "unlzma failed: {}", output.stderr);
     fixture.assert_files(&[FILE_NAME], &[data]);

--- a/xz-cli/tests/test_cli/unlzma/cli_options.rs
+++ b/xz-cli/tests/test_cli/unlzma/cli_options.rs
@@ -1,0 +1,117 @@
+use crate::add_test;
+use crate::common::{generate_random_data, Fixture, SAMPLE_TEXT};
+use crate::MB;
+
+// Test `--threads` / `-T` option (ignored for `.lzma`).
+add_test!(threads_ignored, async {
+    const FILE_NAME: &str = "threads.txt";
+
+    let data = SAMPLE_TEXT.as_bytes();
+    let mut fixture = Fixture::with_file(FILE_NAME, data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let lzma_path = fixture.lzma_path(FILE_NAME);
+
+    // Create .lzma file.
+    let output = fixture.run_cargo("lzma", &["-k", &file_path]).await;
+    assert!(output.status.success(), "lzma failed: {}", output.stderr);
+
+    fixture.remove_file(FILE_NAME);
+
+    // `--threads` is accepted for CLI compatibility but ignored for `.lzma`.
+    let output = fixture
+        .run_cargo("unlzma", &["-T", "4", "-k", &lzma_path])
+        .await;
+    assert!(output.status.success(), "unlzma failed: {}", output.stderr);
+    fixture.assert_files(&[FILE_NAME], &[data]);
+});
+
+// Test `--memory` / `--memlimit` / `-M` option.
+add_test!(memlimit_too_small_is_reported, async {
+    const FILE_NAME: &str = "memlimit.txt";
+
+    // Large enough to ensure decompression needs more than a tiny limit.
+    let data = generate_random_data(MB);
+    let mut fixture = Fixture::with_file(FILE_NAME, &data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let lzma_path = fixture.lzma_path(FILE_NAME);
+
+    // Use explicit lzma1 dict to ensure predictable memory requirements.
+    let out = fixture
+        .run_cargo(
+            "xz",
+            &[
+                "--format=lzma",
+                "--lzma1",
+                "dict=16MiB,lc=3,lp=0,pb=2,mode=normal,mf=bt4,nice=128,depth=0",
+                "-k",
+                &file_path,
+            ],
+        )
+        .await;
+    assert!(out.status.success(), "xz failed: {}", out.stderr);
+
+    fixture.remove_file(FILE_NAME);
+
+    // Decompress with a very small limit.
+    let out = fixture.run_cargo("unlzma", &["-M", "1K", &lzma_path]).await;
+    assert!(!out.status.success(), "unlzma unexpectedly succeeded");
+    assert!(
+        out.stderr.contains("Memory usage limit reached"),
+        "unexpected stderr: {}",
+        out.stderr
+    );
+});
+
+// Test `--suffix` option.
+add_test!(custom_suffix_option, async {
+    const FILE_NAME: &str = "suffix.txt";
+
+    let data = SAMPLE_TEXT.as_bytes();
+    let mut fixture = Fixture::with_file(FILE_NAME, data);
+
+    let file_path = fixture.path(FILE_NAME);
+
+    // Create .foo using lzma.
+    let out = fixture
+        .run_cargo("lzma", &["--suffix=.foo", "-k", &file_path])
+        .await;
+    assert!(out.status.success(), "lzma failed: {}", out.stderr);
+    assert!(fixture.file_exists("suffix.txt.foo"));
+
+    fixture.remove_file(FILE_NAME);
+
+    let foo_path = format!("{}.foo", fixture.path(FILE_NAME));
+    let out = fixture
+        .run_cargo("unlzma", &["--suffix=.foo", &foo_path])
+        .await;
+    assert!(out.status.success(), "unlzma failed: {}", out.stderr);
+    fixture.assert_files(&[FILE_NAME], &[data]);
+});
+
+// Test `--suffix` option without leading dot.
+add_test!(custom_suffix_without_dot, async {
+    const FILE_NAME: &str = "suffix_no_dot.txt";
+
+    let data = SAMPLE_TEXT.as_bytes();
+    let mut fixture = Fixture::with_file(FILE_NAME, data);
+
+    let file_path = fixture.path(FILE_NAME);
+
+    // Create `.foo` using lzma without leading dot in suffix.
+    let out = fixture
+        .run_cargo("lzma", &["--suffix=foo", "-k", &file_path])
+        .await;
+    assert!(out.status.success(), "lzma failed: {}", out.stderr);
+    assert!(fixture.file_exists("suffix_no_dot.txt.foo"));
+
+    fixture.remove_file(FILE_NAME);
+
+    let foo_path = format!("{}.foo", fixture.path(FILE_NAME));
+    let out = fixture
+        .run_cargo("unlzma", &["--suffix=foo", &foo_path])
+        .await;
+    assert!(out.status.success(), "unlzma failed: {}", out.stderr);
+    fixture.assert_files(&[FILE_NAME], &[data]);
+});

--- a/xz-cli/tests/test_cli/unlzma/edge_cases.rs
+++ b/xz-cli/tests/test_cli/unlzma/edge_cases.rs
@@ -1,0 +1,22 @@
+use crate::add_test;
+use crate::common::{Fixture, SAMPLE_TEXT};
+
+// Test unlzma skips files with unknown suffix.
+add_test!(unknown_suffix_is_skipped, async {
+    const FILE_NAME: &str = "no_suffix";
+
+    let data = SAMPLE_TEXT.as_bytes();
+    let mut fixture = Fixture::with_file(FILE_NAME, data);
+    let file_path = fixture.path(FILE_NAME);
+
+    // unlzma in file->file mode needs to remove a suffix to determine output name.
+    // If there is no recognized suffix, it should warn and skip (like upstream xz).
+    let out = fixture.run_cargo("unlzma", &[&file_path]).await;
+    assert!(!out.status.success());
+    assert!(
+        out.stderr
+            .contains("Filename has an unknown suffix, skipping"),
+        "unexpected stderr: {}",
+        out.stderr
+    );
+});

--- a/xz-cli/tests/test_cli/unlzma/interop.rs
+++ b/xz-cli/tests/test_cli/unlzma/interop.rs
@@ -29,30 +29,3 @@ add_test!(system_xz_lzma_to_our_unlzma, async {
     assert!(output.status.success(), "unlzma failed: {}", output.stderr);
     fixture.assert_files(&[FILE_NAME], &[data]);
 });
-
-// Test our xz (format=lzma) -> system xz -d.
-add_test!(our_xz_lzma_to_system_xz, async {
-    const FILE_NAME: &str = "test.txt";
-
-    let data = SAMPLE_TEXT.as_bytes();
-    let mut fixture = Fixture::with_file(FILE_NAME, data);
-
-    let file_path = fixture.path(FILE_NAME);
-    let lzma_path = fixture.lzma_path(FILE_NAME);
-
-    let output = fixture
-        .run_cargo("xz", &["--format=lzma", "-k", &file_path])
-        .await;
-    assert!(output.status.success(), "our xz failed: {}", output.stderr);
-
-    fixture.remove_file(FILE_NAME);
-
-    let Some(system_out) = fixture.run_system("xz", &["-d", &lzma_path]).await else {
-        return;
-    };
-    assert!(
-        system_out.status.success(),
-        "system xz -d failed: {}",
-        system_out.stderr
-    );
-});

--- a/xz-cli/tests/test_cli/unlzma/mod.rs
+++ b/xz-cli/tests/test_cli/unlzma/mod.rs
@@ -1,0 +1,3 @@
+// unlzma is covered by the lzma integration tests.
+
+

--- a/xz-cli/tests/test_cli/unlzma/mod.rs
+++ b/xz-cli/tests/test_cli/unlzma/mod.rs
@@ -1,3 +1,1 @@
 // unlzma is covered by the lzma integration tests.
-
-

--- a/xz-cli/tests/test_cli/unlzma/mod.rs
+++ b/xz-cli/tests/test_cli/unlzma/mod.rs
@@ -1,1 +1,4 @@
-// unlzma is covered by the lzma integration tests.
+mod basic;
+mod cli_options;
+mod edge_cases;
+mod interop;

--- a/xz-cli/tests/test_cli/xz/cli_options.rs
+++ b/xz-cli/tests/test_cli/xz/cli_options.rs
@@ -80,6 +80,50 @@ add_test!(memory_limit_option, async {
     fixture.assert_files(&[FILE_NAME], &[&data]);
 });
 
+// `--lzma1` is only meaningful with `--format=lzma`, but it should be accepted and work.
+add_test!(lzma1_options_roundtrip, async {
+    const FILE_NAME: &str = "lzma1.txt";
+
+    let data = b"hello";
+    let mut fixture = Fixture::with_file(FILE_NAME, data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let lzma_path = fixture.lzma_path(FILE_NAME);
+
+    let opts = "dict=1MiB,lc=4,lp=0,pb=2,mode=fast,mf=hc4,nice=64,depth=128";
+    let output = fixture
+        .run_cargo("xz", &["--format=lzma", "--lzma1", opts, "-k", &file_path])
+        .await;
+    assert!(output.status.success(), "xz failed: {}", output.stderr);
+    assert!(fixture.file_exists("lzma1.txt.lzma"));
+
+    fixture.remove_file(FILE_NAME);
+
+    let output = fixture.run_cargo("unlzma", &[&lzma_path]).await;
+    assert!(output.status.success(), "unlzma failed: {}", output.stderr);
+    fixture.assert_files(&[FILE_NAME], &[data]);
+});
+
+// Test invalid `--lzma1` option.
+add_test!(lzma1_options_invalid_rejected, async {
+    const FILE_NAME: &str = "lzma1_invalid.txt";
+
+    let data = b"hello";
+    let mut fixture = Fixture::with_file(FILE_NAME, data);
+
+    let file_path = fixture.path(FILE_NAME);
+
+    let output = fixture
+        .run_cargo("xz", &["--format=lzma", "--lzma1=lc=9", "-k", &file_path])
+        .await;
+    assert!(!output.status.success());
+    assert!(
+        output.stderr.contains("lzma1") || output.stderr.contains("lc"),
+        "unexpected stderr: {}",
+        output.stderr
+    );
+});
+
 // Test -v (verbose) option
 add_test!(verbose_option, async {
     const FILE_NAME: &str = "verbose_test.txt";

--- a/xz-cli/utils/math.rs
+++ b/xz-cli/utils/math.rs
@@ -11,9 +11,6 @@ pub(crate) fn ratio_fraction(compressed: u64, uncompressed: u64) -> f64 {
     let scaled = compressed.saturating_mul(1_000_000);
     let ratio_micro = (scaled + (uncompressed / 2)) / uncompressed;
 
-    let ratio_micro_u32 = match u32::try_from(ratio_micro) {
-        Ok(v) => v,
-        Err(_) => u32::MAX,
-    };
+    let ratio_micro_u32 = u32::try_from(ratio_micro).unwrap_or(u32::MAX);
     f64::from(ratio_micro_u32) / 1_000_000.0
 }

--- a/xz-core/README.md
+++ b/xz-core/README.md
@@ -157,6 +157,20 @@ Key knobs:
 - `Threading` intelligently caps worker counts to avoid starving the host,
 while `DecodeMode` lets you pick between XZ, legacy LZMA, or auto-detection.
 
+## Legacy `.lzma` Support
+
+`xz-core` supports decoding and encoding the legacy `.lzma` (LZMA_Alone) container via:
+
+- `EncodeFormat::Lzma` for compression (LZMA1 only)
+- `DecodeMode::Lzma` for decompression
+- `DecodeMode::Auto` for auto-detection (XZ or `.lzma`, single-threaded only)
+
+Limitations of the `.lzma` container:
+
+- No integrity checks (CRC/SHA) are stored in the container.
+- Always single-threaded (threading is not supported for `.lzma`).
+- Custom filter chains are not supported; the container always uses LZMA1.
+
 ## Memory & Buffer Management
 
 The pipeline allocates scratch buffers via `Buffer`.

--- a/xz-core/src/config.rs
+++ b/xz-core/src/config.rs
@@ -36,6 +36,15 @@ pub enum DecodeMode {
     Lzma,
 }
 
+/// Encoder container format selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EncodeFormat {
+    /// XZ container format (default).
+    Xz,
+    /// Legacy `.lzma` (`LZMA_Alone`) container format.
+    Lzma,
+}
+
 /// Statistical summary of completed stream processing operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StreamSummary {

--- a/xz-core/src/lib.rs
+++ b/xz-core/src/lib.rs
@@ -139,6 +139,14 @@
 //!     .with_memlimit_stop(Some(NonZeroU64::new(128 * 1024 * 1024).unwrap())) // 128MB hard limit
 //!     .with_mode(DecodeMode::Auto);                                   // Auto-detect format
 //! ```
+//!
+//! ## Legacy `.lzma` (`LZMA_Alone`)
+//!
+//! The legacy `.lzma` container is supported for compatibility with older tooling:
+//!
+//! - Encoding uses LZMA1 only and is always single-threaded.
+//! - The `.lzma` container doesn't store integrity checks (CRC/SHA).
+//! - Custom filter chains are not supported for `.lzma`.
 
 mod buffer;
 mod error;

--- a/xz-core/src/lib.rs
+++ b/xz-core/src/lib.rs
@@ -180,10 +180,7 @@ pub fn ratio(numerator: u64, denominator: u64) -> f64 {
     let numerator = u128::from(numerator);
     let scaled = numerator.saturating_mul(1000);
     let percent_tenths = (scaled + (denominator / 2)) / denominator;
-    let percent_tenths_u32 = match u32::try_from(percent_tenths) {
-        Ok(v) => v,
-        Err(_) => u32::MAX,
-    };
+    let percent_tenths_u32 = u32::try_from(percent_tenths).unwrap_or(u32::MAX);
 
     f64::from(percent_tenths_u32) / 10.0
 }

--- a/xz-core/src/options.rs
+++ b/xz-core/src/options.rs
@@ -4,7 +4,6 @@ use std::num::{NonZeroU64, NonZeroUsize};
 use std::time::Duration;
 
 use lzma_safe::decoder::options::{Flags as DecoderFlags, Options as DecoderMtOptions};
-use lzma_safe::encoder::options::Lzma1Options;
 use lzma_safe::encoder::options::Options as EncoderMtOptions;
 use lzma_safe::{AloneEncoder, Decoder, Encoder, Stream};
 
@@ -12,6 +11,11 @@ pub use lzma_safe::decoder::options::Flags;
 pub use lzma_safe::encoder::options::{
     Compression, FilterConfig, FilterOptions, FilterType, IntegrityCheck,
 };
+
+/// LZMA1 encoder tuning options exposed for `.lzma` (`LZMA_Alone`) usage.
+pub mod lzma1 {
+    pub use lzma_safe::encoder::options::{Lzma1Options, MatchFinder, Mode};
+}
 
 use crate::config::DecodeMode;
 use crate::config::EncodeFormat;
@@ -31,7 +35,7 @@ pub struct CompressionOptions {
     timeout: Option<Duration>,
     filters: Vec<FilterConfig>,
     format: EncodeFormat,
-    lzma1: Option<Lzma1Options>,
+    lzma1: Option<lzma1::Lzma1Options>,
     input_buffer_size: NonZeroUsize,
     output_buffer_size: NonZeroUsize,
 }
@@ -174,7 +178,7 @@ impl CompressionOptions {
     ///
     /// If not specified, the LZMA1 options are derived from the selected compression preset.
     #[must_use]
-    pub fn with_lzma1_options(mut self, options: Option<Lzma1Options>) -> Self {
+    pub fn with_lzma1_options(mut self, options: Option<lzma1::Lzma1Options>) -> Self {
         self.lzma1 = options;
         self
     }
@@ -274,7 +278,7 @@ impl CompressionOptions {
 
         let options = match self.lzma1.clone() {
             Some(v) => v,
-            None => Lzma1Options::from_preset(self.level).map_err(Error::from)?,
+            None => lzma1::Lzma1Options::from_preset(self.level).map_err(Error::from)?,
         };
         AloneEncoder::new(options, Stream::default()).map_err(Error::from)
     }

--- a/xz-core/src/options.rs
+++ b/xz-core/src/options.rs
@@ -378,7 +378,7 @@ impl DecompressionOptions {
     ///
     /// Available modes:
     ///
-    /// - `DecodeMode::Auto`: Automatically detect XZ or LZMA format (single-threaded only)
+    /// - `DecodeMode::Auto`: Automatically detect XZ or legacy `.lzma` format (single-threaded only)
     /// - `DecodeMode::Xz`: Force XZ format parsing (supports multi-threading)
     /// - `DecodeMode::Lzma`: Force LZMA format parsing (single-threaded only)
     #[must_use]

--- a/xz-core/src/pipeline/async.rs
+++ b/xz-core/src/pipeline/async.rs
@@ -1,12 +1,12 @@
 //! Asynchronous XZ compression and decompression pipeline.
 
-use lzma_safe::{Action, Decoder, Encoder};
+use lzma_safe::{Action, Decoder};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::buffer::Buffer;
 use crate::config::StreamSummary;
 use crate::error::{BackendError, Result};
-use crate::options::{CompressionOptions, DecompressionOptions};
+use crate::options::{BuiltEncoder, CompressionOptions, DecompressionOptions};
 
 /// Compresses data asynchronously from a reader into a writer using the provided options.
 ///
@@ -216,7 +216,7 @@ where
 /// * `Ok(())` if the encoder finished successfully
 /// * `Err(BackendError::BufError)` if the encoder gets stuck in an infinite loop
 async fn finish_encoder_async<W: AsyncWrite + Unpin>(
-    encoder: &mut Encoder,
+    encoder: &mut BuiltEncoder,
     writer: &mut W,
     output: &mut [u8],
     total_out: &mut u64,

--- a/xz-core/src/pipeline/sync.rs
+++ b/xz-core/src/pipeline/sync.rs
@@ -2,12 +2,12 @@
 
 use std::io::{Read, Write};
 
-use lzma_safe::{Action, Decoder, Encoder};
+use lzma_safe::{Action, Decoder};
 
 use crate::buffer::Buffer;
 use crate::config::StreamSummary;
 use crate::error::{BackendError, Result};
-use crate::options::{CompressionOptions, DecompressionOptions};
+use crate::options::{BuiltEncoder, CompressionOptions, DecompressionOptions};
 
 /// Compresses data from a reader into a writer using the provided options.
 ///
@@ -215,7 +215,7 @@ where
 /// * `Ok(())` if the encoder finished successfully
 /// * `Err(BackendError::BufError)` if the encoder gets stuck in an infinite loop
 fn finish_encoder_sync<W: Write>(
-    encoder: &mut Encoder,
+    encoder: &mut BuiltEncoder,
     writer: &mut W,
     output: &mut [u8],
     total_out: &mut u64,


### PR DESCRIPTION
### Summary
This PR adds support for the legacy .lzma (LZMA_Alone) format and brings the CLI behavior closer to upstream xz in --lzma1 parsing, .lzma mode constraints, error/diagnostics formatting, and integration test coverage.

### lzma-safe

- Added an LZMA_Alone encoder (alone) and integrated it into the encoder module.
- Added/extended LZMA1 encoder options with additional validation and tests.
- Updated error/FFI surfaces where needed to support the new paths.

### xz-cli

- Made --lzma1 parsing more upstream-compatible (dictionary bounds, lc+lp invariant, size suffixes, max).
- Added/updated options and behavior for lzma/unlzma/lzcat family:
> --suffix for lzma/unlzma.
> --single-stream for lzcat/xzcat.
> Enforced .lzma-specific constraints and aligned compatibility behavior (including ignoring --threads where not applicable).
- Improved I/O and backend error formatting to match upstream xz more closely (including message mapping).
- xz-core
- Documented legacy .lzma support and limitations and locked decode mode semantics.

### xz-core

Documented legacy .lzma support and limitations and locked decode mode semantics.