### PR TITLE
xz-cli: preserve trailing dots when generating compressed output names

### DIFF
--- a/xz-cli/io/mod.rs
+++ b/xz-cli/io/mod.rs
@@ -83,11 +83,7 @@ pub fn generate_output_filename(
             }
 
             // If the file has an extension, append the compression extension after it
-            match input
-                .extension()
-                .and_then(OsStr::to_str)
-                .filter(|ext| !ext.is_empty())
-            {
+            match input.extension().and_then(OsStr::to_str) {
                 Some(ext) => {
                     let new_ext = format!("{ext}.{extension}");
                     output.set_extension(new_ext);

--- a/xz-cli/tests.rs
+++ b/xz-cli/tests.rs
@@ -102,6 +102,22 @@ fn generate_output_filename_compress_basic() {
     assert_eq!(output, PathBuf::from("test.xz"));
 }
 
+/// Compression output generation preserves trailing dots like `xz` does.
+#[test]
+fn generate_output_filename_compress_trailing_dots() {
+    let input = Path::new("file.");
+    let output =
+        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false)
+            .unwrap();
+    assert_eq!(output, PathBuf::from("file..xz"));
+
+    let input = Path::new("file..");
+    let output =
+        generate_output_filename(input, OperationMode::Compress, None, XZ_EXTENSION, false)
+            .unwrap();
+    assert_eq!(output, PathBuf::from("file...xz"));
+}
+
 /// Test compression with existing .xz extension
 #[test]
 fn generate_output_filename_compress_double_extension() {


### PR DESCRIPTION
Treat an empty extension as a real extension. Add unit test for this.