### PR TITLE
xzless: implement file pager for XZ-compressed files

### DIFF
--- a/xz-cli/bin/xzless/main.rs
+++ b/xz-cli/bin/xzless/main.rs
@@ -1,11 +1,138 @@
-//! XZ-compressed file pager utility
+//! XZ-compressed file pager utility.
 //!
-//! This utility displays XZ-compressed files using the 'less' pager
-//! without explicitly decompressing them to disk.
+//! This utility displays compressed files by transparently decompressing them
+//! and forwarding the resulting paths to a pager (by default `less`).
 
-use std::io;
+use std::env;
+use std::ffi::{OsStr, OsString};
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::process::{self, Command, Stdio};
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> io::Result<()> {
-    unreachable!("Not implemented yet");
+use tempfile::NamedTempFile;
+
+use xz_cli::{decompress_file, has_compression_extension, open_input, CliConfig, OperationMode};
+
+const PROGRAM_NAME: &str = "xzless";
+
+mod opts;
+
+fn main() {
+    match run() {
+        Ok(code) => process::exit(code),
+        Err(err) => {
+            eprintln!("{PROGRAM_NAME}: {err}");
+            process::exit(2);
+        }
+    }
+}
+
+/// Execute the `xzless` command.
+///
+/// # Returns
+///
+/// Returns the exit code from the selected pager.
+fn run() -> Result<i32, String> {
+    let args: Vec<OsString> = env::args_os().skip(1).collect();
+    let parsed = opts::parse_args(&args);
+
+    if parsed.show_help {
+        print_usage(&parsed.pager_program);
+        return Ok(0);
+    }
+
+    if parsed.show_version {
+        print_version();
+        return Ok(0);
+    }
+
+    let files = if parsed.files.is_empty() {
+        vec![OsString::from("-")]
+    } else {
+        parsed.files.clone()
+    };
+
+    // stdin cannot be meaningfully consumed more than once.
+    let stdin_count = files.iter().filter(|file| *file == OsStr::new("-")).count();
+    if stdin_count > 0 && files.len() > 1 {
+        return Err("'-' can only be used as the sole input".to_string());
+    }
+
+    let config = CliConfig {
+        mode: OperationMode::Decompress,
+        no_warn: false,
+        ..CliConfig::default()
+    };
+
+    // Keep tempfiles alive while pager is running.
+    let mut temps: Vec<NamedTempFile> = Vec::new();
+    let mut pager_inputs: Vec<PathBuf> = Vec::new();
+
+    for file in &files {
+        let path = prepare_input_for_pager(file, &config, &mut temps)?;
+        pager_inputs.push(path);
+    }
+
+    let mut cmd = Command::new(&parsed.pager_program);
+    cmd.args(&parsed.pager_args);
+    cmd.arg("--");
+    cmd.args(&pager_inputs);
+    cmd.stdin(Stdio::inherit());
+    cmd.stdout(Stdio::inherit());
+    cmd.stderr(Stdio::inherit());
+
+    let status = cmd.status().map_err(|err| err.to_string())?;
+    Ok(status.code().unwrap_or(2))
+}
+
+/// Print usage text to stdout.
+fn print_usage(pager_program: &OsStr) {
+    let pager = pager_program.to_string_lossy();
+    println!(
+        "Usage: xzless [OPTION]... [FILE]...\n\
+Display FILEs in a pager, using their uncompressed contents if they are\n\
+compressed. If no FILE is specified, read from standard input.\n\n\
+OPTIONs are the same as for '{pager}'.\n",
+    );
+}
+
+/// Print version text to stdout.
+fn print_version() {
+    println!("{PROGRAM_NAME} (xz-rs) {}", env!("CARGO_PKG_VERSION"));
+}
+
+/// Prepare an input path suitable for the pager.
+///
+/// If the input looks like a supported compressed file, it is decompressed into
+/// a temporary file and that temporary path is returned. Otherwise, the original
+/// path is returned.
+fn prepare_input_for_pager(
+    file: &OsStr,
+    config: &CliConfig,
+    temps: &mut Vec<NamedTempFile>,
+) -> Result<PathBuf, String> {
+    if file == OsStr::new("-") {
+        return Ok(PathBuf::from("-"));
+    }
+
+    let path = Path::new(file);
+    if !has_compression_extension(path) {
+        return Ok(path.to_path_buf());
+    }
+
+    let mut input = open_input(
+        path.to_str()
+            .ok_or_else(|| "Non-UTF8 paths are not supported".to_string())?,
+    )
+    .map_err(|err| err.to_string())?;
+
+    let tmp = NamedTempFile::new().map_err(|err| err.to_string())?;
+    {
+        let mut out = File::create(tmp.path()).map_err(|err| err.to_string())?;
+        decompress_file(&mut input, &mut out, config).map_err(|err| err.to_string())?;
+    }
+
+    let out_path = tmp.path().to_path_buf();
+    temps.push(tmp);
+    Ok(out_path)
 }

--- a/xz-cli/bin/xzless/opts.rs
+++ b/xz-cli/bin/xzless/opts.rs
@@ -1,0 +1,104 @@
+//! Argument handling for `xzless`.
+
+use std::env;
+use std::ffi::{OsStr, OsString};
+
+/// Parsed command-line arguments for `xzless`.
+#[derive(Debug, Clone)]
+pub struct ParsedArgs {
+    /// Pager binary to execute (defaults to `less`, can be overridden via `PAGER`).
+    pub pager_program: OsString,
+    /// Options forwarded to the underlying pager invocation.
+    pub pager_args: Vec<OsString>,
+    /// Input file operands as provided by the user.
+    pub files: Vec<OsString>,
+    /// Whether `--help` (or `--h*`) was requested.
+    pub show_help: bool,
+    /// Whether `--version` (or `--v*`) was requested.
+    pub show_version: bool,
+}
+
+/// Parse `xzless` CLI arguments.
+///
+/// This intentionally does *not* validate options: unknown flags are forwarded
+/// to the pager to match the behavior of wrapper tools like `xzgrep`.
+pub fn parse_args(args: &[OsString]) -> ParsedArgs {
+    let pager_program = env::var_os("PAGER").unwrap_or_else(|| OsString::from("less"));
+
+    let mut pager_args: Vec<OsString> = Vec::new();
+    let mut files: Vec<OsString> = Vec::new();
+    let mut show_help = false;
+    let mut show_version = false;
+
+    let mut it = args.iter().cloned().peekable();
+
+    while let Some(arg) = it.peek().cloned() {
+        let text = arg.to_string_lossy();
+        if text.starts_with("--h") {
+            show_help = true;
+            it.next();
+            continue;
+        }
+        if text.starts_with("--v") {
+            show_version = true;
+            it.next();
+            continue;
+        }
+
+        if arg == OsStr::new("--") {
+            it.next();
+            break;
+        }
+
+        // Stop option parsing at the first non-option, but treat "-" as a file operand.
+        if text.starts_with('-') && arg != OsStr::new("-") {
+            pager_args.push(arg);
+            it.next();
+            continue;
+        }
+
+        break;
+    }
+
+    for arg in it {
+        files.push(arg);
+    }
+
+    ParsedArgs {
+        pager_program,
+        pager_args,
+        files,
+        show_help,
+        show_version,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `-` must be treated as a file operand, not as a pager option.
+    #[test]
+    fn parse_args_treats_dash_as_operand() {
+        let args = vec![OsString::from("-"), OsString::from("file.txt")];
+        let parsed = parse_args(&args);
+
+        assert!(parsed.pager_args.is_empty());
+        assert!(parsed.files == vec![OsString::from("-"), OsString::from("file.txt")]);
+    }
+
+    /// Options must be forwarded to the pager until the first operand or `--`.
+    #[test]
+    fn parse_args_splits_options_and_files() {
+        let args = vec![
+            OsString::from("-F"),
+            OsString::from("--"),
+            OsString::from("a.xz"),
+            OsString::from("b.txt"),
+        ];
+        let parsed = parse_args(&args);
+
+        assert!(parsed.pager_args == vec![OsString::from("-F")]);
+        assert!(parsed.files == vec![OsString::from("a.xz"), OsString::from("b.txt")]);
+    }
+}

--- a/xz-cli/tests/test_cli/common/mod.rs
+++ b/xz-cli/tests/test_cli/common/mod.rs
@@ -364,18 +364,20 @@ impl Fixture {
         &mut self,
         binary_type: &BinaryType,
         args: &[&str],
+        env_vars: &[(&str, &str)],
         stdin_bytes: Option<Vec<u8>>,
         kill_receiver: oneshot::Receiver<()>,
     ) -> Output {
         let bin_path = binary_type.get_path();
-        let mut child = tokio::process::Command::new(&bin_path)
+        let mut command = tokio::process::Command::new(&bin_path);
+        command
             .args(args)
+            .envs(env_vars.iter().copied())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .stdin(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .unwrap();
+            .kill_on_drop(true);
+        let mut child = command.spawn().unwrap();
 
         if let Some(stdin_bytes) = stdin_bytes {
             if let Some(ref mut stdin) = child.stdin {
@@ -446,7 +448,7 @@ impl Fixture {
 
         let (kill_sender, kill_receiver) = oneshot::channel();
         let output = self
-            .run_until_killed(&binary_type, args, stdin_bytes, kill_receiver)
+            .run_until_killed(&binary_type, args, &[], stdin_bytes, kill_receiver)
             .await;
         drop(kill_sender);
         output
@@ -466,14 +468,40 @@ impl Fixture {
     ) -> Output {
         let (kill_sender, kill_receiver) = oneshot::channel();
         let output = self
-            .run_until_killed(&binary_type, args, Some(stdin.to_vec()), kill_receiver)
+            .run_until_killed(&binary_type, args, &[], Some(stdin.to_vec()), kill_receiver)
             .await;
         drop(kill_sender);
         output
     }
 
+    /// Run a cargo binary with command-specific environment variables.
+    pub async fn run_cargo_with_env(
+        &mut self,
+        name: &str,
+        args: &[&str],
+        env_vars: &[(&str, &str)],
+    ) -> Output {
+        self.run_with_env(BinaryType::cargo(name), args, env_vars)
+            .await
+    }
+
     /// Run a binary with the specified arguments
     async fn run(&mut self, binary_type: BinaryType, args: &[&str]) -> Output {
         self.run_with_stdin(binary_type, args, None).await
+    }
+
+    /// Run a binary with the specified arguments and environment variables.
+    async fn run_with_env(
+        &mut self,
+        binary_type: BinaryType,
+        args: &[&str],
+        env_vars: &[(&str, &str)],
+    ) -> Output {
+        let (kill_sender, kill_receiver) = oneshot::channel();
+        let output = self
+            .run_until_killed(&binary_type, args, env_vars, None, kill_receiver)
+            .await;
+        drop(kill_sender);
+        output
     }
 }

--- a/xz-cli/tests/test_cli/main.rs
+++ b/xz-cli/tests/test_cli/main.rs
@@ -9,6 +9,7 @@ mod xzcmp;
 mod xzdec;
 mod xzdiff;
 mod xzgrep;
+mod xzless;
 
 const KB: usize = 1024;
 const MB: usize = 1024 * KB;

--- a/xz-cli/tests/test_cli/xzless/basic.rs
+++ b/xz-cli/tests/test_cli/xzless/basic.rs
@@ -1,0 +1,41 @@
+use crate::add_test;
+use crate::common::Fixture;
+
+// Test that xzless shows decompressed content for .xz files.
+add_test!(shows_decompressed_content, async {
+    const FILE: &str = "file.txt";
+    let contents = b"line one\nline two\n";
+
+    let mut fixture = Fixture::with_file(FILE, contents);
+
+    let out = fixture.run_cargo("xz", &["-k", &fixture.path(FILE)]).await;
+    assert!(out.status.success());
+
+    let file_xz = fixture.compressed_path(FILE);
+    let out = fixture
+        .run_cargo_with_env("xzless", &[&file_xz], &[("PAGER", "cat")])
+        .await;
+
+    assert!(out.status.success());
+    assert!(out.stdout_raw == contents);
+});
+
+// Test that xzless forwards pager options to the selected pager.
+add_test!(forwards_pager_options, async {
+    const FILE: &str = "opts.txt";
+    let contents = b"blabla\nblublu\n";
+
+    let mut fixture = Fixture::with_file(FILE, contents);
+
+    let out = fixture.run_cargo("xz", &["-k", &fixture.path(FILE)]).await;
+    assert!(out.status.success());
+
+    let file_xz = fixture.compressed_path(FILE);
+    let out = fixture
+        .run_cargo_with_env("xzless", &["-n", &file_xz], &[("PAGER", "cat")])
+        .await;
+
+    assert!(out.status.success());
+    assert!(out.stdout.contains("1\tblabla"));
+    assert!(out.stdout.contains("2\tblublu"));
+});

--- a/xz-cli/tests/test_cli/xzless/cli_options.rs
+++ b/xz-cli/tests/test_cli/xzless/cli_options.rs
@@ -1,0 +1,23 @@
+use crate::add_test;
+use crate::common::Fixture;
+
+// Test that `--help` exits successfully and prints usage text.
+add_test!(help_option_prints_usage, async {
+    let mut fixture = Fixture::with_file("dummy.txt", b"pupupu");
+
+    let out = fixture
+        .run_cargo_with_env("xzless", &["--help"], &[("PAGER", "cat")])
+        .await;
+    assert!(out.status.success());
+    assert!(out.stdout.contains("Usage:"));
+});
+
+// Test that `--version` exits successfully.
+add_test!(version_option_succeeds, async {
+    let mut fixture = Fixture::with_file("dummy.txt", b"yayayay");
+
+    let out = fixture
+        .run_cargo_with_env("xzless", &["--version"], &[("PAGER", "cat")])
+        .await;
+    assert!(out.status.success());
+});

--- a/xz-cli/tests/test_cli/xzless/edge_cases.rs
+++ b/xz-cli/tests/test_cli/xzless/edge_cases.rs
@@ -1,0 +1,25 @@
+use crate::add_test;
+use crate::common::Fixture;
+
+// Test that a missing compressed file yields exit code 2.
+add_test!(missing_compressed_file_yields_exit_2, async {
+    let mut fixture = Fixture::with_file("file.txt", b"hello\n");
+
+    let missing = fixture.path("b.txt.xz");
+    let out = fixture
+        .run_cargo_with_env("xzless", &[&missing], &[("PAGER", "cat")])
+        .await;
+
+    assert!(out.status.code() == Some(2));
+});
+
+// Test that `-` cannot be combined with other files.
+add_test!(dash_with_other_files_is_error, async {
+    let mut fixture = Fixture::with_file("file.txt", b"foo\n");
+    let file = fixture.path("file.txt");
+
+    let out = fixture
+        .run_cargo_with_env("xzless", &["-", &file], &[("PAGER", "cat")])
+        .await;
+    assert!(out.status.code() == Some(2));
+});

--- a/xz-cli/tests/test_cli/xzless/mod.rs
+++ b/xz-cli/tests/test_cli/xzless/mod.rs
@@ -1,0 +1,3 @@
+mod basic;
+mod cli_options;
+mod edge_cases;


### PR DESCRIPTION
Add the `xzless` utility to display XZ-compressed files using a pager without decompressing them to disk.