### PR TITLE
Add support for handling unknown input in decompression

### DIFF
--- a/lzma-safe/liblzma-sys/src/lib.rs
+++ b/lzma-safe/liblzma-sys/src/lib.rs
@@ -16,3 +16,6 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 // This is typically used for pre-generated bindings or when bindgen is not available.
 #[cfg(not(feature = "bindgen"))]
 include!("lzma_bindings.rs");
+
+/// Size of the legacy LZMA_Alone header in bytes.
+pub const LZMA_ALONE_HEADER_SIZE: usize = 1 + 4 + 8;

--- a/lzma-safe/src/lib.rs
+++ b/lzma-safe/src/lib.rs
@@ -45,6 +45,9 @@ pub use encoder::{AloneEncoder, Encoder, RawEncoder};
 pub use error::{Error, Result};
 pub use stream::{BlockInfo, Index, IndexEntry, IndexIterMode, IndexIterator, Stream, StreamInfo};
 
+/// Size of the legacy LZMA_Alone header in bytes.
+pub const LZMA_ALONE_HEADER_SIZE: usize = liblzma_sys::LZMA_ALONE_HEADER_SIZE;
+
 /// Access to the liblzma version reported by the linked C library.
 pub struct Version;
 

--- a/xz-cli/bin/xzcmp/main.rs
+++ b/xz-cli/bin/xzcmp/main.rs
@@ -119,8 +119,12 @@ fn materialize_for_cmp(
 
     let tmp = NamedTempFile::new().map_err(|e| e.to_string())?;
     {
+        // `xzcmp` always reads from named paths here; stdin is passed through
+        // directly to `cmp` without going through the decompressor.
+        let stdin_input = false;
+
         let mut out = File::create(tmp.path()).map_err(|e| e.to_string())?;
-        decompress_file(&mut input, &mut out, config).map_err(|e| e.to_string())?;
+        decompress_file(&mut input, &mut out, config, stdin_input).map_err(|e| e.to_string())?;
     }
 
     let out_path = tmp.path().to_path_buf();

--- a/xz-cli/bin/xzdiff/main.rs
+++ b/xz-cli/bin/xzdiff/main.rs
@@ -118,8 +118,12 @@ fn materialize_for_diff(
 
     let tmp = NamedTempFile::new().map_err(|e| e.to_string())?;
     {
+        // `xzdiff` always reads from named paths here; stdin is passed through
+        // directly to `diff` without going through the decompressor.
+        let stdin_input = false;
+
         let mut out = File::create(tmp.path()).map_err(|e| e.to_string())?;
-        decompress_file(&mut input, &mut out, config).map_err(|e| e.to_string())?;
+        decompress_file(&mut input, &mut out, config, stdin_input).map_err(|e| e.to_string())?;
     }
 
     let out_path = tmp.path().to_path_buf();

--- a/xz-cli/bin/xzless/main.rs
+++ b/xz-cli/bin/xzless/main.rs
@@ -128,8 +128,12 @@ fn prepare_input_for_pager(
 
     let tmp = NamedTempFile::new().map_err(|err| err.to_string())?;
     {
+        // `xzless` always reads from named files here, never stdin.
+        let stdin_input = false;
+
         let mut out = File::create(tmp.path()).map_err(|err| err.to_string())?;
-        decompress_file(&mut input, &mut out, config).map_err(|err| err.to_string())?;
+        decompress_file(&mut input, &mut out, config, stdin_input)
+            .map_err(|err| err.to_string())?;
     }
 
     let out_path = tmp.path().to_path_buf();

--- a/xz-cli/bin/xzmore/main.rs
+++ b/xz-cli/bin/xzmore/main.rs
@@ -128,8 +128,12 @@ fn prepare_input_for_pager(
 
     let tmp = NamedTempFile::new().map_err(|err| err.to_string())?;
     {
+        // `xzmore` always reads from named files here, never stdin.
+        let stdin_input = false;
+
         let mut out = File::create(tmp.path()).map_err(|err| err.to_string())?;
-        decompress_file(&mut input, &mut out, config).map_err(|err| err.to_string())?;
+        decompress_file(&mut input, &mut out, config, stdin_input)
+            .map_err(|err| err.to_string())?;
     }
 
     let out_path = tmp.path().to_path_buf();

--- a/xz-cli/operations.rs
+++ b/xz-cli/operations.rs
@@ -2,18 +2,17 @@
 
 use std::fs::File;
 use std::io;
-use std::io::Read as _;
 
 use xz_core::{
     config::EncodeFormat,
-    detect_unsupported_xz_check_id, file_info,
+    file_info,
     options::lzma1::Lzma1Options,
     options::{
         Compression, CompressionOptions, DecompressionOptions, FilterConfig, FilterOptions,
         FilterType, Flags, LzmaOptions,
     },
     pipeline::{compress, decompress},
-    ratio, read_xz_stream_header_prefix, Error as CoreError,
+    ratio, Error as CoreError, UnknownInputPolicy,
 };
 
 use crate::config::CliConfig;
@@ -327,12 +326,12 @@ fn decompress_raw(
 
     options = apply_memlimit(options, config);
 
-    let summary = decompress(input, output, &options).map_err(|e| {
+    let outcome = decompress(input, output, &options).map_err(|e| {
         let message = xz_message_from_core_error(&e);
         DiagnosticCause::from(Error::Decompression { message })
     })?;
 
-    emit_decompress_summary(config, summary.bytes_read, summary.bytes_written);
+    emit_decompress_summary(config, outcome.bytes_read, outcome.bytes_written);
     Ok(())
 }
 
@@ -358,6 +357,7 @@ fn warn_unsupported_check(unsupported_check_id: Option<u32>, config: &CliConfig)
 /// * `input` - Reader providing compressed XZ or LZMA data
 /// * `output` - Writer receiving decompressed data
 /// * `config` - CLI configuration specifying threads, memory limits, and verbosity
+/// * `stdin_input` - Indicates that the current input source is standard input
 ///
 /// # Returns
 ///
@@ -376,37 +376,42 @@ pub fn decompress_file(
     mut input: impl io::Read,
     mut output: impl io::Write,
     config: &CliConfig,
+    stdin_input: bool,
 ) -> Result<()> {
     if config.format == xz_core::config::DecodeMode::Raw {
         return decompress_raw(&mut input, &mut output, config);
     }
 
-    // Read and preserve a small prefix so we can inspect the XZ Stream Header without
-    // losing bytes from the actual decode stream.
-    let prefix = read_xz_stream_header_prefix(&mut input).map_err(|source| {
-        DiagnosticCause::from(Error::OpenInput {
-            source: IoErrorNoCode::new(source),
-        })
-    })?;
-
-    let unsupported_check_id = detect_unsupported_xz_check_id(&prefix);
-
-    let mut input = io::Cursor::new(prefix).chain(input);
+    let unknown_input_policy = if config.mode == crate::config::OperationMode::Decompress
+        && config.stdout
+        && config.format == xz_core::config::DecodeMode::Auto
+        && stdin_input
+    {
+        // Mirror upstream `xz`: when reading from stdin in `xz -dc`-style
+        // invocation, unknown input is copied to stdout unchanged.
+        UnknownInputPolicy::Passthrough
+    } else {
+        // For named files and all other modes, unknown input must be
+        // treated as an error so that corrupted `.xz` files (including
+        // those with invalid header magic) cause a non-zero exit status.
+        UnknownInputPolicy::Error
+    };
 
     let options = DecompressionOptions::default()
         .with_mode(config.format)
-        .with_flags(build_decoder_flags(config));
+        .with_flags(build_decoder_flags(config))
+        .with_unknown_input_policy(unknown_input_policy);
     let options = apply_threads_for_decompression(options, config)?;
     let options = apply_memlimit(options, config);
 
-    let summary = decompress(&mut input, &mut output, &options).map_err(|e| {
+    let outcome = decompress(&mut input, &mut output, &options).map_err(|e| {
         let message = xz_message_from_core_error(&e);
         DiagnosticCause::from(Error::Decompression { message })
     })?;
 
-    emit_decompress_summary(config, summary.bytes_read, summary.bytes_written);
+    emit_decompress_summary(config, outcome.bytes_read, outcome.bytes_written);
 
-    warn_unsupported_check(unsupported_check_id, config)
+    warn_unsupported_check(outcome.unsupported_check_id, config)
 }
 
 /// Lists information about an XZ compressed file.

--- a/xz-cli/process.rs
+++ b/xz-cli/process.rs
@@ -158,7 +158,7 @@ pub fn process_file(input_path: &str, config: &CliConfig) -> Result<()> {
             compress_file(input, output, config)?;
         }
         OperationMode::Decompress | OperationMode::Cat => {
-            match decompress_file(input, output, config) {
+            match decompress_file(input, output, config, is_stdin) {
                 Ok(()) => (),
                 Err(DiagnosticCause::Warning(
                     w @ crate::error::Warning::UnsupportedCheck { .. },
@@ -171,7 +171,7 @@ pub fn process_file(input_path: &str, config: &CliConfig) -> Result<()> {
         }
         OperationMode::Test => {
             // In test mode, decompress but discard output
-            decompress_file(input, io::sink(), config)?;
+            decompress_file(input, io::sink(), config, is_stdin)?;
 
             if config.verbose || config.robot {
                 if config.robot {

--- a/xz-cli/tests.rs
+++ b/xz-cli/tests.rs
@@ -430,6 +430,7 @@ fn compress_decompress_roundtrip() {
         Cursor::new(&compressed),
         &mut decompressed,
         &decompress_config,
+        false,
     )
     .expect("Decompression should succeed");
 
@@ -511,7 +512,8 @@ fn decompress_corrupted_data() {
     let mut output_vec = Vec::new();
     let config = CliConfig::default();
 
-    let err = decompress_file(Cursor::new(corrupted_data), &mut output_vec, &config).unwrap_err();
+    let err =
+        decompress_file(Cursor::new(corrupted_data), &mut output_vec, &config, false).unwrap_err();
     assert!(matches!(
         err,
         DiagnosticCause::Error(Error::Decompression { .. })
@@ -559,6 +561,7 @@ fn extreme_mode_default_level() {
         Cursor::new(&output),
         &mut decompressed,
         &CliConfig::default(),
+        false,
     )
     .unwrap();
 
@@ -647,6 +650,7 @@ fn memory_limit_decompression() {
         Cursor::new(&compressed),
         &mut output_vec,
         &decompress_config,
+        false,
     )
     .expect("Decompression with memory limit should succeed");
 
@@ -671,7 +675,7 @@ fn zero_memory_limit() {
         ..Default::default()
     };
 
-    decompress_file(Cursor::new(&compressed), &mut output, &config)
+    decompress_file(Cursor::new(&compressed), &mut output, &config, false)
         .expect("Zero memory limit should not cause failure");
 }
 
@@ -714,7 +718,7 @@ fn default_decodes_concatenated_xz_streams() {
     };
 
     let mut decoded = Vec::new();
-    match decompress_file(Cursor::new(concatenated), &mut decoded, &config) {
+    match decompress_file(Cursor::new(concatenated), &mut decoded, &config, false) {
         Ok(()) => {}
         Err(err) => panic!("decompress_file(default) failed: {err:?}"),
     }
@@ -744,7 +748,7 @@ fn single_stream_ignores_trailing_stream() {
     };
 
     let mut decoded = Vec::new();
-    match decompress_file(Cursor::new(concatenated), &mut decoded, &config) {
+    match decompress_file(Cursor::new(concatenated), &mut decoded, &config, false) {
         Ok(()) => {}
         Err(err) => panic!("decompress_file(--single-stream) failed: {err:?}"),
     }

--- a/xz-cli/tests/test_cli/xz/formats.rs
+++ b/xz-cli/tests/test_cli/xz/formats.rs
@@ -335,6 +335,19 @@ add_test!(raw_format_stdin_writes_to_stdout, async {
     assert!(!output.stdout_raw.is_empty());
 });
 
+// Test auto-decompress mode copies unknown stdin to stdout when `-c` is used.
+add_test!(auto_decompress_unknown_stdin_copies_to_stdout, async {
+    let mut fixture = Fixture::with_file("stdin-anchor.txt", b"anchor");
+
+    let input = b"foo";
+    let output = fixture
+        .run_with_stdin_raw(BinaryType::cargo("xz"), &["-d", "-c"], input)
+        .await;
+
+    assert!(output.status.success());
+    assert_eq!(output.stdout_raw.as_slice(), input);
+});
+
 // Test raw mode rejects --files without a suffix because it cannot derive output names.
 add_test!(raw_format_files_requires_suffix, async {
     const FILE_NAME: &str = "raw_files_input.txt";

--- a/xz-core/src/config.rs
+++ b/xz-core/src/config.rs
@@ -10,7 +10,7 @@ pub enum DecodeMode {
     /// limited to single-threaded operation for security and simplicity.
     ///
     /// **Threading**: Single-threaded only
-    /// **Formats**: XZ (.xz) and LZMA (.lzma)
+    /// **Formats**: XZ (.xz), LZMA (.lzma), and lzip (.lz)
     /// **Use case**: Processing streams of unknown format
     Auto,
 
@@ -40,6 +40,24 @@ pub enum DecodeMode {
     /// This mode has no container metadata, so the caller must configure the filter chain
     /// out-of-band and threading is not supported.
     Raw,
+}
+
+/// Policy controlling how auto-detect decompression handles unknown input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnknownInputPolicy {
+    /// Return an error when the input doesn't look like a supported container.
+    Error,
+    /// Copy the original input to the output unchanged.
+    Passthrough,
+}
+
+/// High-level result status for a decompression operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecompressionStatus {
+    /// Input was decoded as a supported compressed stream.
+    Decompressed,
+    /// Input was copied to the output unchanged.
+    Passthrough,
 }
 
 /// Encoder container format selection.
@@ -110,6 +128,62 @@ impl StreamSummary {
     /// The space saved as a percentage (0.0 to 100.0). Positive values indicate
     /// space was saved through compression. Negative values indicate the output
     /// was larger than the input (expansion occurred).
+    pub fn space_saved_percent(&self) -> f64 {
+        if self.bytes_read == 0 {
+            0.0
+        } else {
+            let ratio = self.compression_ratio();
+            (1.0 - ratio) * 100.0
+        }
+    }
+}
+
+/// Result of a completed decompression operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DecompressionOutcome {
+    /// Total number of bytes read from the input source.
+    pub bytes_read: u64,
+
+    /// Total number of bytes written to the output destination.
+    pub bytes_written: u64,
+
+    /// Whether the pipeline decoded compressed data or passed the input through.
+    pub status: DecompressionStatus,
+
+    /// Integrity check ID from the XZ stream header when it isn't supported by liblzma.
+    pub unsupported_check_id: Option<u32>,
+}
+
+impl DecompressionOutcome {
+    /// Creates a new decompression outcome from a stream summary and metadata.
+    pub(crate) const fn new(
+        summary: StreamSummary,
+        status: DecompressionStatus,
+        unsupported_check_id: Option<u32>,
+    ) -> Self {
+        Self {
+            bytes_read: summary.bytes_read,
+            bytes_written: summary.bytes_written,
+            status,
+            unsupported_check_id,
+        }
+    }
+
+    /// Calculates the compression ratio for this outcome.
+    #[allow(clippy::cast_precision_loss)]
+    pub fn compression_ratio(&self) -> f64 {
+        if self.bytes_read == 0 {
+            if self.bytes_written == 0 {
+                0.0
+            } else {
+                f64::INFINITY
+            }
+        } else {
+            self.bytes_written as f64 / self.bytes_read as f64
+        }
+    }
+
+    /// Calculates the space saved percentage for compression operations.
     pub fn space_saved_percent(&self) -> f64 {
         if self.bytes_read == 0 {
             0.0

--- a/xz-core/src/header.rs
+++ b/xz-core/src/header.rs
@@ -2,23 +2,28 @@
 
 use std::io;
 
-/// Size of the XZ Stream Header in bytes (12 bytes).
-pub const XZ_STREAM_HEADER_SIZE: usize = lzma_safe::stream::HEADER_SIZE;
+/// Size of the legacy LZMA_Alone header in bytes.
+pub const LZMA_ALONE_HEADER_SIZE: usize = lzma_safe::LZMA_ALONE_HEADER_SIZE;
 
 /// Magic bytes at the beginning of an XZ Stream Header.
 pub const XZ_STREAM_HEADER_MAGIC: [u8; 6] = lzma_safe::stream::HEADER_MAGIC;
 
-/// Reads up to one XZ Stream Header from `input` without requiring EOF.
+/// Magic bytes at the beginning of an lzip member.
+pub const LZIP_HEADER_MAGIC: [u8; 4] = *b"LZIP";
+
+/// Number of bytes needed to distinguish the auto-detected decoder formats.
+pub const DECODE_FORMAT_PROBE_SIZE: usize = LZMA_ALONE_HEADER_SIZE;
+
+/// Reads enough bytes from `input` to identify the formats supported by auto-detection.
 ///
-/// This is intended for callers that want to peek at the header (e.g. to inspect the
-/// integrity check type) and then re-chain the bytes back into the decode stream.
+/// The returned prefix can be chained back into the decode stream after probing.
 ///
 /// # Errors
 ///
 /// Returns an error if reading from `input` fails.
-pub fn read_xz_stream_header_prefix(input: &mut impl io::Read) -> io::Result<Vec<u8>> {
-    let mut prefix = Vec::with_capacity(XZ_STREAM_HEADER_SIZE);
-    let mut tmp = [0_u8; XZ_STREAM_HEADER_SIZE];
+pub fn read_decode_format_probe_prefix(input: &mut impl io::Read) -> io::Result<Vec<u8>> {
+    let mut prefix = Vec::with_capacity(DECODE_FORMAT_PROBE_SIZE);
+    let mut tmp = [0_u8; DECODE_FORMAT_PROBE_SIZE];
 
     while prefix.len() < tmp.len() {
         let offset = prefix.len();
@@ -44,5 +49,113 @@ pub fn detect_unsupported_xz_check_id(prefix: &[u8]) -> Option<u32> {
         (!lzma_safe::lzma_check_is_supported(check_id)).then_some(check_id)
     } else {
         None
+    }
+}
+
+/// Returns `true` when the probe prefix looks like `.xz`, legacy `.lzma`, or `.lz`.
+pub fn is_known_decode_format(prefix: &[u8]) -> bool {
+    prefix.starts_with(&XZ_STREAM_HEADER_MAGIC)
+        || prefix.starts_with(&LZIP_HEADER_MAGIC)
+        || is_lzma_alone_header(prefix)
+}
+
+/// Returns `true` when the probe prefix looks like a legacy `.lzma` header.
+fn is_lzma_alone_header(prefix: &[u8]) -> bool {
+    if prefix.len() < LZMA_ALONE_HEADER_SIZE {
+        return false;
+    }
+
+    let properties = prefix[0];
+    if properties >= 9 * 5 * 5 {
+        return false;
+    }
+
+    let mut dict_size_bytes = [0_u8; 4];
+    dict_size_bytes.copy_from_slice(&prefix[1..5]);
+    let dict_size = u32::from_le_bytes(dict_size_bytes);
+    if dict_size != u32::MAX && !is_picky_lzma_dict_size(dict_size) {
+        return false;
+    }
+
+    let mut uncompressed_size_bytes = [0_u8; 8];
+    uncompressed_size_bytes.copy_from_slice(&prefix[5..LZMA_ALONE_HEADER_SIZE]);
+    let uncompressed_size = u64::from_le_bytes(uncompressed_size_bytes);
+    uncompressed_size == u64::MAX || uncompressed_size < (1_u64 << 38)
+}
+
+/// Returns `true` when the LZMA dictionary size is valid.
+fn is_picky_lzma_dict_size(dict_size: u32) -> bool {
+    if dict_size == 0 {
+        return false;
+    }
+
+    let mut rounded = dict_size - 1;
+    rounded |= rounded >> 2;
+    rounded |= rounded >> 3;
+    rounded |= rounded >> 4;
+    rounded |= rounded >> 8;
+    rounded |= rounded >> 16;
+    rounded = rounded.wrapping_add(1);
+
+    rounded == dict_size
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        is_known_decode_format, read_decode_format_probe_prefix, LZIP_HEADER_MAGIC,
+        LZMA_ALONE_HEADER_SIZE, XZ_STREAM_HEADER_MAGIC,
+    };
+
+    /// Detect `.xz` input from the stream header magic.
+    #[test]
+    fn detects_xz_probe_prefix() {
+        let mut prefix = Vec::from(XZ_STREAM_HEADER_MAGIC);
+        prefix.resize(LZMA_ALONE_HEADER_SIZE, 0);
+        assert!(is_known_decode_format(&prefix));
+    }
+
+    /// Detect lzip input from the member magic.
+    #[test]
+    fn detects_lzip_probe_prefix() {
+        let mut prefix = Vec::from(LZIP_HEADER_MAGIC);
+        prefix.resize(LZMA_ALONE_HEADER_SIZE, 0);
+        assert!(is_known_decode_format(&prefix));
+    }
+
+    /// Detect a plausible legacy `.lzma` header.
+    #[test]
+    fn detects_lzma_alone_probe_prefix() {
+        #[rustfmt::skip]
+        let prefix = [
+            0x5D,                                           // lc/lp/pb
+            0x00, 0x00, 0x80, 0x00,                         // 8 MiB dictionary
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // unknown size
+        ];
+        assert!(is_known_decode_format(&prefix));
+    }
+
+    /// Reject arbitrary input that doesn't match any supported format.
+    #[test]
+    fn rejects_unknown_probe_prefix() {
+        assert!(!is_known_decode_format(b"foo"));
+    }
+
+    /// Read at most the auto-detect probe size from the input.
+    #[test]
+    fn reads_decode_probe_prefix_without_requiring_eof() {
+        #[rustfmt::skip]
+        let input = [
+            0x5D,                                           // lc/lp/pb
+            0x00, 0x00, 0x80, 0x00,                         // 8 MiB dictionary
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // unknown size
+            b'x',                                           // trailing bytes
+            b'y',
+        ];
+        let mut cursor = std::io::Cursor::new(input);
+
+        let prefix = read_decode_format_probe_prefix(&mut cursor).unwrap();
+
+        assert_eq!(prefix.len(), LZMA_ALONE_HEADER_SIZE);
     }
 }

--- a/xz-core/src/lib.rs
+++ b/xz-core/src/lib.rs
@@ -64,7 +64,7 @@
 //! let mut output = Vec::new();
 //!
 //! let options = DecompressionOptions::default();
-//! let summary = decompress(
+//! let outcome = decompress(
 //!     &mut Cursor::new(&compressed_data),
 //!     &mut output,
 //!     &options,
@@ -72,7 +72,7 @@
 //! assert_eq!(output, input);
 //!
 //! println!("Decompressed {} bytes to {} bytes",
-//!          summary.bytes_read, summary.bytes_written);
+//!          outcome.bytes_read, outcome.bytes_written);
 //! # Ok(())
 //! # }
 //! ```
@@ -160,11 +160,12 @@ pub mod pipeline;
 
 pub use crate::error::{BackendError, Error, Result};
 pub use crate::header::{
-    detect_unsupported_xz_check_id, read_xz_stream_header_prefix, XZ_STREAM_HEADER_MAGIC,
-    XZ_STREAM_HEADER_SIZE,
+    detect_unsupported_xz_check_id, is_known_decode_format, read_decode_format_probe_prefix,
+    LZMA_ALONE_HEADER_SIZE, XZ_STREAM_HEADER_MAGIC,
 };
 pub use crate::threading::Threading;
 pub use buffer::{Allocator, Buffer, Deallocator, DeallocatorFn, GlobalAllocator};
+pub use config::{DecompressionOutcome, DecompressionStatus, UnknownInputPolicy};
 
 /// Calculates the compression/decompression ratio as a percentage.
 ///

--- a/xz-core/src/options.rs
+++ b/xz-core/src/options.rs
@@ -18,7 +18,7 @@ pub mod lzma1 {
 }
 
 use crate::config::DecodeMode;
-use crate::config::EncodeFormat;
+use crate::config::{EncodeFormat, UnknownInputPolicy};
 use crate::error::{Error, Result};
 use crate::threading::{sanitize_threads, Threading};
 
@@ -366,6 +366,7 @@ pub struct DecompressionOptions {
     memlimit_stop: Option<NonZeroU64>,
     flags: DecoderFlags,
     mode: DecodeMode,
+    unknown_input_policy: UnknownInputPolicy,
     raw_lzma1: Option<lzma1::Lzma1Options>,
     timeout: Option<Duration>,
     input_buffer_size: NonZeroUsize,
@@ -380,6 +381,7 @@ impl Default for DecompressionOptions {
             memlimit_stop: None,
             flags: DecoderFlags::empty(),
             mode: DecodeMode::Auto,
+            unknown_input_policy: UnknownInputPolicy::Error,
             raw_lzma1: None,
             timeout: None,
             input_buffer_size: NonZeroUsize::new(DEFAULT_INPUT_BUFFER).unwrap(),
@@ -447,11 +449,19 @@ impl DecompressionOptions {
     /// Available modes:
     ///
     /// - `DecodeMode::Auto`: Automatically detect XZ or legacy `.lzma` format (single-threaded only)
+    ///   and lzip `.lz` members.
     /// - `DecodeMode::Xz`: Force XZ format parsing (supports multi-threading)
     /// - `DecodeMode::Lzma`: Force LZMA format parsing (single-threaded only)
     #[must_use]
     pub fn with_mode(mut self, mode: DecodeMode) -> Self {
         self.mode = mode;
+        self
+    }
+
+    /// Controls how auto-detect mode handles input that doesn't look like a supported container.
+    #[must_use]
+    pub fn with_unknown_input_policy(mut self, policy: UnknownInputPolicy) -> Self {
+        self.unknown_input_policy = policy;
         self
     }
 
@@ -588,6 +598,14 @@ impl DecompressionOptions {
     pub(crate) fn flags(&self) -> DecoderFlags {
         self.flags
     }
+
+    pub(crate) fn mode(&self) -> DecodeMode {
+        self.mode
+    }
+
+    pub(crate) fn unknown_input_policy(&self) -> UnknownInputPolicy {
+        self.unknown_input_policy
+    }
 }
 
 /// Converts a `Duration` to a timeout value in milliseconds for the LZMA library.
@@ -694,6 +712,7 @@ mod tests {
         assert_eq!(options.memlimit.get(), 256 * 1024 * 1024); // 256MB default
         assert_eq!(options.threads, Threading::Auto);
         assert_eq!(options.mode, DecodeMode::Auto);
+        assert_eq!(options.unknown_input_policy, UnknownInputPolicy::Error);
         assert!(options.flags.is_empty());
     }
 
@@ -725,6 +744,7 @@ mod tests {
             .with_memlimit_stop(Some(memlimit_stop))
             .with_flags(Flags::CONCATENATED)
             .with_mode(DecodeMode::Xz)
+            .with_unknown_input_policy(UnknownInputPolicy::Passthrough)
             .with_timeout(Some(Duration::from_secs(10)));
 
         assert_eq!(options.threads, Threading::Exact(2));
@@ -732,6 +752,10 @@ mod tests {
         assert_eq!(options.memlimit_stop, Some(memlimit_stop));
         assert!(options.flags.is_concatenated());
         assert_eq!(options.mode, DecodeMode::Xz);
+        assert_eq!(
+            options.unknown_input_policy,
+            UnknownInputPolicy::Passthrough
+        );
         assert_eq!(options.timeout, Some(Duration::from_secs(10)));
     }
 

--- a/xz-core/src/pipeline/async.rs
+++ b/xz-core/src/pipeline/async.rs
@@ -4,11 +4,13 @@ use lzma_safe::Action;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::buffer::Buffer;
-use crate::config::StreamSummary;
+use crate::config::{DecompressionOutcome, StreamSummary};
 use crate::error::{BackendError, Result};
 use crate::options::{BuiltDecoder, BuiltEncoder, CompressionOptions, DecompressionOptions};
 
-use super::decode::{DecoderSession, ReadAction, RunAction};
+use super::decode::{
+    passthrough_async, probe_async, DecoderSession, PrefixedAsyncReader, ReadAction, RunAction,
+};
 
 /// Compresses data asynchronously from a reader into a writer using the provided options.
 ///
@@ -99,6 +101,26 @@ where
 /// - Memory limits are exceeded during decompression
 /// - Threading is requested for unsupported decode modes
 pub async fn decompress_async<R, W>(
+    mut reader: R,
+    mut writer: W,
+    options: &DecompressionOptions,
+) -> Result<DecompressionOutcome>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let probe = probe_async(&mut reader, options).await?;
+    if probe.is_passthrough() {
+        let summary = passthrough_async(probe.prefix(), &mut reader, &mut writer).await?;
+        return Ok(probe.build_outcome(summary));
+    }
+
+    let mut reader = PrefixedAsyncReader::new(probe.prefix().to_vec(), reader);
+    let summary = decompress_stream_async(&mut reader, &mut writer, options).await?;
+    Ok(probe.build_outcome(summary))
+}
+
+async fn decompress_stream_async<R, W>(
     mut reader: R,
     mut writer: W,
     options: &DecompressionOptions,
@@ -253,7 +275,7 @@ mod tests {
     use std::num::{NonZeroU64, NonZeroUsize};
     use std::time::Duration;
 
-    use crate::config::DecodeMode;
+    use crate::config::{DecodeMode, DecompressionStatus, UnknownInputPolicy};
     use crate::options::{
         Compression, CompressionOptions, DecompressionOptions, Flags, IntegrityCheck,
     };
@@ -793,6 +815,37 @@ mod tests {
         let mut decompressed = Vec::new();
 
         let result = decompress_async(reader, &mut decompressed, &decompression_options).await;
+
+        assert!(matches!(result, Err(crate::error::Error::Backend(_))));
+    });
+
+    // Test that auto mode can passthrough unknown input when explicitly enabled.
+    async_test!(unknown_input_passthrough_policy_copies_original_bytes, {
+        let input = b"foo";
+        let options = DecompressionOptions::default()
+            .with_unknown_input_policy(UnknownInputPolicy::Passthrough);
+        let mut output = Vec::new();
+
+        let outcome = decompress_async(input.as_slice(), &mut output, &options)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.status, DecompressionStatus::Passthrough);
+        assert_eq!(outcome.bytes_read, input.len() as u64);
+        assert_eq!(outcome.bytes_written, input.len() as u64);
+        assert_eq!(outcome.unsupported_check_id, None);
+        assert_eq!(output, input);
+    });
+
+    // Test that unknown input still fails without the passthrough policy.
+    async_test!(unknown_input_without_passthrough_policy_errors, {
+        let mut output = Vec::new();
+        let result = decompress_async(
+            b"foo".as_slice(),
+            &mut output,
+            &DecompressionOptions::default(),
+        )
+        .await;
 
         assert!(matches!(result, Err(crate::error::Error::Backend(_))));
     });

--- a/xz-core/src/pipeline/decode.rs
+++ b/xz-core/src/pipeline/decode.rs
@@ -1,13 +1,22 @@
 //! Shared decoder state machine used by sync and async pipelines.
 
+use std::io::{self, Read};
+
 use lzma_safe::Action;
 
 use crate::buffer::Buffer;
-use crate::config::StreamSummary;
+use crate::config::{
+    DecodeMode, DecompressionOutcome, DecompressionStatus, StreamSummary, UnknownInputPolicy,
+};
 use crate::error::{BackendError, Error, Result};
+use crate::header::{
+    detect_unsupported_xz_check_id, is_known_decode_format, read_decode_format_probe_prefix,
+    LZIP_HEADER_MAGIC,
+};
 use crate::options::{BuiltDecoder, DecompressionOptions, Flags};
 
-const LZIP_MAGIC: [u8; 4] = *b"LZIP";
+/// Size of the I/O buffer used by the decoder during passthrough.
+const IO_BUFFER_SIZE: usize = 8192;
 
 /// Describes how the next read should populate the input buffer.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -42,6 +51,206 @@ impl RunOutcome {
     fn new(written: usize, action: RunAction) -> Self {
         Self { written, action }
     }
+}
+
+/// Probe result captured before starting decompression.
+pub struct DecompressionProbe {
+    prefix: Vec<u8>,
+    status: DecompressionStatus,
+    unsupported_check_id: Option<u32>,
+}
+
+impl DecompressionProbe {
+    /// Probe a synchronous reader before creating the decode stream.
+    pub fn read_sync<R: Read>(reader: &mut R, options: &DecompressionOptions) -> io::Result<Self> {
+        if options.mode() == DecodeMode::Raw {
+            return Ok(Self::decoded(Vec::new(), None));
+        }
+
+        let prefix = read_decode_format_probe_prefix(reader)?;
+        Ok(Self::classify(prefix, options))
+    }
+
+    /// Returns `true` if the pipeline should passthrough the input.
+    pub fn is_passthrough(&self) -> bool {
+        self.status == DecompressionStatus::Passthrough
+    }
+
+    /// Returns the preserved probe prefix.
+    pub fn prefix(&self) -> &[u8] {
+        &self.prefix
+    }
+
+    /// Builds the final decompression outcome from a stream summary.
+    pub fn build_outcome(&self, summary: StreamSummary) -> DecompressionOutcome {
+        DecompressionOutcome::new(summary, self.status, self.unsupported_check_id)
+    }
+
+    fn decoded(prefix: Vec<u8>, unsupported_check_id: Option<u32>) -> Self {
+        Self {
+            prefix,
+            status: DecompressionStatus::Decompressed,
+            unsupported_check_id,
+        }
+    }
+
+    fn classify(prefix: Vec<u8>, options: &DecompressionOptions) -> Self {
+        let unsupported_check_id = detect_unsupported_xz_check_id(&prefix);
+        let should_passthrough = options.mode() == DecodeMode::Auto
+            && options.unknown_input_policy() == UnknownInputPolicy::Passthrough
+            && !prefix.is_empty()
+            && !is_known_decode_format(&prefix);
+
+        if should_passthrough {
+            Self {
+                prefix,
+                status: DecompressionStatus::Passthrough,
+                unsupported_check_id: None,
+            }
+        } else {
+            Self::decoded(prefix, unsupported_check_id)
+        }
+    }
+}
+
+/// Copy already-read prefix and the remaining reader contents to the output unchanged.
+pub fn passthrough_sync<R: Read, W: io::Write>(
+    prefix: &[u8],
+    reader: &mut R,
+    writer: &mut W,
+) -> io::Result<StreamSummary> {
+    let mut bytes_read = 0_u64;
+    let mut bytes_written = 0_u64;
+
+    if !prefix.is_empty() {
+        writer.write_all(prefix)?;
+        let prefix_len = prefix.len() as u64;
+        bytes_read += prefix_len;
+        bytes_written += prefix_len;
+    }
+
+    let mut buffer = [0_u8; IO_BUFFER_SIZE];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+
+        writer.write_all(&buffer[..read])?;
+        bytes_read += read as u64;
+        bytes_written += read as u64;
+    }
+
+    writer.flush()?;
+    Ok(StreamSummary::new(bytes_read, bytes_written))
+}
+
+#[cfg(feature = "async")]
+/// Async reader wrapper that drains a prefetched prefix before polling the inner reader.
+pub struct PrefixedAsyncReader<R> {
+    prefix: Vec<u8>,
+    prefix_pos: usize,
+    inner: R,
+}
+
+#[cfg(feature = "async")]
+impl<R> PrefixedAsyncReader<R> {
+    /// Creates a new async reader wrapper with a preserved prefix.
+    pub fn new(prefix: Vec<u8>, inner: R) -> Self {
+        Self {
+            prefix,
+            prefix_pos: 0,
+            inner,
+        }
+    }
+}
+
+#[cfg(feature = "async")]
+impl<R> tokio::io::AsyncRead for PrefixedAsyncReader<R>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        if self.prefix_pos < self.prefix.len() {
+            let remaining = self.prefix.len() - self.prefix_pos;
+            let to_copy = remaining.min(buf.remaining());
+            let end = self.prefix_pos + to_copy;
+            buf.put_slice(&self.prefix[self.prefix_pos..end]);
+            self.prefix_pos = end;
+            return std::task::Poll::Ready(Ok(()));
+        }
+
+        std::pin::Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+#[cfg(feature = "async")]
+/// Probe an async reader before starting decompression.
+pub async fn probe_async<R>(
+    reader: &mut R,
+    options: &DecompressionOptions,
+) -> io::Result<DecompressionProbe>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    if options.mode() == DecodeMode::Raw {
+        return Ok(DecompressionProbe::decoded(Vec::new(), None));
+    }
+
+    let mut prefix = Vec::with_capacity(crate::header::DECODE_FORMAT_PROBE_SIZE);
+    let mut buffer = [0_u8; crate::header::DECODE_FORMAT_PROBE_SIZE];
+
+    while prefix.len() < buffer.len() {
+        let offset = prefix.len();
+        let read = tokio::io::AsyncReadExt::read(reader, &mut buffer[offset..]).await?;
+        if read == 0 {
+            break;
+        }
+        prefix.extend_from_slice(&buffer[offset..offset + read]);
+    }
+
+    Ok(DecompressionProbe::classify(prefix, options))
+}
+
+#[cfg(feature = "async")]
+/// Copy already-read prefix and the remaining async reader contents to the output unchanged.
+pub async fn passthrough_async<R, W>(
+    prefix: &[u8],
+    reader: &mut R,
+    writer: &mut W,
+) -> io::Result<StreamSummary>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    let mut bytes_read = 0_u64;
+    let mut bytes_written = 0_u64;
+
+    if !prefix.is_empty() {
+        tokio::io::AsyncWriteExt::write_all(writer, prefix).await?;
+        let prefix_len = prefix.len() as u64;
+        bytes_read += prefix_len;
+        bytes_written += prefix_len;
+    }
+
+    let mut buffer = [0_u8; IO_BUFFER_SIZE];
+    loop {
+        let read = tokio::io::AsyncReadExt::read(reader, &mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+
+        tokio::io::AsyncWriteExt::write_all(writer, &buffer[..read]).await?;
+        bytes_read += read as u64;
+        bytes_written += read as u64;
+    }
+
+    tokio::io::AsyncWriteExt::flush(writer).await?;
+    Ok(StreamSummary::new(bytes_read, bytes_written))
 }
 
 /// Shared decoder session state.
@@ -282,7 +491,7 @@ impl DecoderBootstrap {
         options: &DecompressionOptions,
         first_chunk: &[u8],
     ) -> Result<Self> {
-        let detected_lzip_input = first_chunk.starts_with(&LZIP_MAGIC);
+        let detected_lzip_input = first_chunk.starts_with(&LZIP_HEADER_MAGIC);
         if detected_lzip_input && options.flags().is_concatenated() {
             let mut lzip_flags = options.flags();
             lzip_flags.remove(Flags::CONCATENATED);
@@ -332,5 +541,5 @@ pub fn should_stop_after_stream_end(
         return true;
     }
 
-    detected_lzip_input && !next_bytes.is_empty() && !next_bytes.starts_with(&LZIP_MAGIC)
+    detected_lzip_input && !next_bytes.is_empty() && !next_bytes.starts_with(&LZIP_HEADER_MAGIC)
 }

--- a/xz-core/src/pipeline/sync.rs
+++ b/xz-core/src/pipeline/sync.rs
@@ -5,11 +5,11 @@ use std::io::{Read, Write};
 use lzma_safe::Action;
 
 use crate::buffer::Buffer;
-use crate::config::StreamSummary;
+use crate::config::{DecompressionOutcome, StreamSummary};
 use crate::error::{BackendError, Result};
 use crate::options::{BuiltDecoder, BuiltEncoder, CompressionOptions, DecompressionOptions};
 
-use super::decode::{DecoderSession, ReadAction, RunAction};
+use super::decode::{passthrough_sync, DecoderSession, DecompressionProbe, ReadAction, RunAction};
 
 /// Compresses data from a reader into a writer using the provided options.
 ///
@@ -100,6 +100,27 @@ where
 /// - Memory limits are exceeded during decompression
 /// - Threading is requested for unsupported decode modes
 pub fn decompress<R, W>(
+    mut reader: R,
+    mut writer: W,
+    options: &DecompressionOptions,
+) -> Result<DecompressionOutcome>
+where
+    R: Read,
+    W: Write,
+{
+    let probe = DecompressionProbe::read_sync(&mut reader, options)?;
+    if probe.is_passthrough() {
+        let summary = passthrough_sync(probe.prefix(), &mut reader, &mut writer)?;
+        return Ok(probe.build_outcome(summary));
+    }
+
+    let prefix = probe.prefix().to_vec();
+    let mut reader = std::io::Cursor::new(prefix).chain(reader);
+    let summary = decompress_stream(&mut reader, &mut writer, options)?;
+    Ok(probe.build_outcome(summary))
+}
+
+fn decompress_stream<R, W>(
     mut reader: R,
     mut writer: W,
     options: &DecompressionOptions,
@@ -253,7 +274,7 @@ mod tests {
     use std::num::{NonZeroU64, NonZeroUsize};
     use std::time::Duration;
 
-    use crate::config::DecodeMode;
+    use crate::config::{DecodeMode, DecompressionStatus, UnknownInputPolicy};
     use crate::options::{
         Compression, CompressionOptions, DecompressionOptions, Flags, IntegrityCheck,
     };
@@ -757,6 +778,36 @@ mod tests {
         let mut decompressed = Vec::new();
 
         let result = decompress(reader, &mut decompressed, &decompression_options);
+
+        assert!(matches!(result, Err(crate::error::Error::Backend(_))));
+    }
+
+    /// Test that auto mode can passthrough unknown input when explicitly enabled.
+    #[test]
+    fn sync_unknown_input_passthrough_policy_copies_original_bytes() {
+        let input = b"foo";
+        let options = DecompressionOptions::default()
+            .with_unknown_input_policy(UnknownInputPolicy::Passthrough);
+        let mut output = Vec::new();
+
+        let outcome = decompress(input.as_slice(), &mut output, &options).unwrap();
+
+        assert_eq!(outcome.status, DecompressionStatus::Passthrough);
+        assert_eq!(outcome.bytes_read, input.len() as u64);
+        assert_eq!(outcome.bytes_written, input.len() as u64);
+        assert_eq!(outcome.unsupported_check_id, None);
+        assert_eq!(output, input);
+    }
+
+    /// Test that unknown input still fails without the passthrough policy.
+    #[test]
+    fn sync_unknown_input_without_passthrough_policy_errors() {
+        let mut output = Vec::new();
+        let result = decompress(
+            b"foo".as_slice(),
+            &mut output,
+            &DecompressionOptions::default(),
+        );
 
         assert!(matches!(result, Err(crate::error::Error::Backend(_))));
     }


### PR DESCRIPTION
This update introduces a new `UnknownInputPolicy` to control how the decompressor manages input that doesn't match known formats. The default behavior raises an error, while the passthrough option allows unknown input to be copied directly to the output.