### PR TITLE
Hardened path and file handling

### DIFF
--- a/xz-cli/bin/lzcat/main.rs
+++ b/xz-cli/bin/lzcat/main.rs
@@ -17,8 +17,9 @@ const PROGRAM_NAME: &str = "lzcat";
 fn main() {
     let opts = LzCatOpts::parse();
     let config = opts.config();
+    let files = opts.files();
 
-    let report = run_cli(opts.files(), &config, PROGRAM_NAME);
+    let report = run_cli(&files, &config, PROGRAM_NAME);
     for diagnostic in &report.diagnostics {
         if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
             eprintln!("{msg}");

--- a/xz-cli/bin/lzcat/main.rs
+++ b/xz-cli/bin/lzcat/main.rs
@@ -17,9 +17,7 @@ const PROGRAM_NAME: &str = "lzcat";
 fn main() {
     let opts = LzCatOpts::parse();
     let config = opts.config();
-    let files = opts.files();
-
-    let report = run_cli(&files, &config, PROGRAM_NAME);
+    let report = run_cli(opts.files(), &config, PROGRAM_NAME);
     for diagnostic in &report.diagnostics {
         if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
             eprintln!("{msg}");

--- a/xz-cli/bin/lzcat/opts.rs
+++ b/xz-cli/bin/lzcat/opts.rs
@@ -1,6 +1,7 @@
 //! Command line argument parsing for the lzcat utility.
 
 use clap::Parser;
+use std::path::PathBuf;
 
 use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 
@@ -84,8 +85,8 @@ impl LzCatOpts {
     }
 
     /// Files supplied on the command line.
-    pub fn files(&self) -> &[String] {
-        &self.files
+    pub fn files(&self) -> Vec<PathBuf> {
+        self.files.iter().map(PathBuf::from).collect()
     }
 }
 
@@ -119,7 +120,7 @@ mod tests {
             Err(e) => panic!("failed to parse aliases: {e}"),
         };
 
-        assert_eq!(opts.files(), ["input.lzma"]);
+        assert_eq!(opts.files(), [PathBuf::from("input.lzma")]);
         assert_eq!(opts.memory, Some(1024 * 1024));
     }
 }

--- a/xz-cli/bin/lzcat/opts.rs
+++ b/xz-cli/bin/lzcat/opts.rs
@@ -1,7 +1,8 @@
 //! Command line argument parsing for the lzcat utility.
 
-use clap::Parser;
 use std::path::PathBuf;
+
+use clap::Parser;
 
 use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 

--- a/xz-cli/bin/lzcat/opts.rs
+++ b/xz-cli/bin/lzcat/opts.rs
@@ -21,7 +21,7 @@ use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 pub struct LzCatOpts {
     /// Files to decompress
     #[arg(value_name = "FILE")]
-    files: Vec<String>,
+    files: Vec<PathBuf>,
 
     /// Verbose mode
     #[arg(short = 'v', long = "verbose", conflicts_with = "quiet")]
@@ -86,8 +86,8 @@ impl LzCatOpts {
     }
 
     /// Files supplied on the command line.
-    pub fn files(&self) -> Vec<PathBuf> {
-        self.files.iter().map(PathBuf::from).collect()
+    pub fn files(&self) -> &[PathBuf] {
+        &self.files
     }
 }
 
@@ -99,7 +99,7 @@ mod tests {
     #[test]
     fn config_uses_lzma_decode_mode() {
         let opts = LzCatOpts {
-            files: vec!["input.lzma".into()],
+            files: vec![PathBuf::from("input.lzma")],
             verbose: false,
             quiet: 0,
             threads: Some(4),

--- a/xz-cli/bin/lzma/main.rs
+++ b/xz-cli/bin/lzma/main.rs
@@ -17,8 +17,9 @@ const PROGRAM_NAME: &str = "lzma";
 fn main() {
     let opts = LzmaOpts::parse();
     let config = opts.config();
+    let files = opts.files();
 
-    let report = run_cli(&opts.files, &config, PROGRAM_NAME);
+    let report = run_cli(&files, &config, PROGRAM_NAME);
     for diagnostic in &report.diagnostics {
         if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
             eprintln!("{msg}");

--- a/xz-cli/bin/lzma/main.rs
+++ b/xz-cli/bin/lzma/main.rs
@@ -17,9 +17,7 @@ const PROGRAM_NAME: &str = "lzma";
 fn main() {
     let opts = LzmaOpts::parse();
     let config = opts.config();
-    let files = opts.files();
-
-    let report = run_cli(&files, &config, PROGRAM_NAME);
+    let report = run_cli(opts.files(), &config, PROGRAM_NAME);
     for diagnostic in &report.diagnostics {
         if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
             eprintln!("{msg}");

--- a/xz-cli/bin/lzma/opts.rs
+++ b/xz-cli/bin/lzma/opts.rs
@@ -1,6 +1,7 @@
 //! Command line argument parsing for the lzma utility.
 
 use clap::Parser;
+use std::path::PathBuf;
 
 use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 
@@ -179,5 +180,10 @@ impl LzmaOpts {
             no_adjust: false,
             sparse: !self.no_sparse,
         }
+    }
+
+    /// Files supplied on the command line
+    pub fn files(&self) -> Vec<PathBuf> {
+        self.files.iter().map(PathBuf::from).collect()
     }
 }

--- a/xz-cli/bin/lzma/opts.rs
+++ b/xz-cli/bin/lzma/opts.rs
@@ -1,7 +1,8 @@
 //! Command line argument parsing for the lzma utility.
 
-use clap::Parser;
 use std::path::PathBuf;
+
+use clap::Parser;
 
 use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 

--- a/xz-cli/bin/lzma/opts.rs
+++ b/xz-cli/bin/lzma/opts.rs
@@ -21,7 +21,7 @@ use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 pub struct LzmaOpts {
     /// Files to process
     #[arg(value_name = "FILE")]
-    pub files: Vec<String>,
+    pub files: Vec<PathBuf>,
 
     /// Force compression
     #[arg(short = 'z', long = "compress", conflicts_with_all = ["decompress", "test"])]
@@ -184,7 +184,7 @@ impl LzmaOpts {
     }
 
     /// Files supplied on the command line
-    pub fn files(&self) -> Vec<PathBuf> {
-        self.files.iter().map(PathBuf::from).collect()
+    pub fn files(&self) -> &[PathBuf] {
+        &self.files
     }
 }

--- a/xz-cli/bin/unlzma/main.rs
+++ b/xz-cli/bin/unlzma/main.rs
@@ -17,8 +17,9 @@ const PROGRAM_NAME: &str = "unlzma";
 fn main() {
     let opts = UnlzmaOpts::parse();
     let config = opts.config();
+    let files = opts.files();
 
-    let report = run_cli(opts.files(), &config, PROGRAM_NAME);
+    let report = run_cli(&files, &config, PROGRAM_NAME);
     for diagnostic in &report.diagnostics {
         if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
             eprintln!("{msg}");

--- a/xz-cli/bin/unlzma/main.rs
+++ b/xz-cli/bin/unlzma/main.rs
@@ -17,9 +17,7 @@ const PROGRAM_NAME: &str = "unlzma";
 fn main() {
     let opts = UnlzmaOpts::parse();
     let config = opts.config();
-    let files = opts.files();
-
-    let report = run_cli(&files, &config, PROGRAM_NAME);
+    let report = run_cli(opts.files(), &config, PROGRAM_NAME);
     for diagnostic in &report.diagnostics {
         if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
             eprintln!("{msg}");

--- a/xz-cli/bin/unlzma/opts.rs
+++ b/xz-cli/bin/unlzma/opts.rs
@@ -1,6 +1,7 @@
 //! Command line argument parsing for the unlzma utility.
 
 use clap::Parser;
+use std::path::PathBuf;
 
 use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 
@@ -110,7 +111,7 @@ impl UnlzmaOpts {
     }
 
     /// Files supplied on the command line.
-    pub fn files(&self) -> &[String] {
-        &self.files
+    pub fn files(&self) -> Vec<PathBuf> {
+        self.files.iter().map(PathBuf::from).collect()
     }
 }

--- a/xz-cli/bin/unlzma/opts.rs
+++ b/xz-cli/bin/unlzma/opts.rs
@@ -21,7 +21,7 @@ use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 pub struct UnlzmaOpts {
     /// Files to decompress
     #[arg(value_name = "FILE")]
-    files: Vec<String>,
+    files: Vec<PathBuf>,
 
     /// Write to standard output and don't delete input files
     #[arg(short = 'c', long = "stdout", alias = "to-stdout")]
@@ -112,7 +112,7 @@ impl UnlzmaOpts {
     }
 
     /// Files supplied on the command line.
-    pub fn files(&self) -> Vec<PathBuf> {
-        self.files.iter().map(PathBuf::from).collect()
+    pub fn files(&self) -> &[PathBuf] {
+        &self.files
     }
 }

--- a/xz-cli/bin/unlzma/opts.rs
+++ b/xz-cli/bin/unlzma/opts.rs
@@ -1,7 +1,8 @@
 //! Command line argument parsing for the unlzma utility.
 
-use clap::Parser;
 use std::path::PathBuf;
+
+use clap::Parser;
 
 use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 

--- a/xz-cli/bin/unxz/main.rs
+++ b/xz-cli/bin/unxz/main.rs
@@ -17,8 +17,9 @@ const PROGRAM_NAME: &str = "unxz";
 fn main() {
     let opts = UnxzOpts::parse();
     let config = opts.config();
+    let files = opts.files();
 
-    let report = run_cli(opts.files(), &config, PROGRAM_NAME);
+    let report = run_cli(&files, &config, PROGRAM_NAME);
     for diagnostic in &report.diagnostics {
         if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
             eprintln!("{msg}");

--- a/xz-cli/bin/unxz/main.rs
+++ b/xz-cli/bin/unxz/main.rs
@@ -17,9 +17,7 @@ const PROGRAM_NAME: &str = "unxz";
 fn main() {
     let opts = UnxzOpts::parse();
     let config = opts.config();
-    let files = opts.files();
-
-    let report = run_cli(&files, &config, PROGRAM_NAME);
+    let report = run_cli(opts.files(), &config, PROGRAM_NAME);
     for diagnostic in &report.diagnostics {
         if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
             eprintln!("{msg}");

--- a/xz-cli/bin/unxz/opts.rs
+++ b/xz-cli/bin/unxz/opts.rs
@@ -1,6 +1,7 @@
 //! Command line argument parsing for the unxz utility.
 
 use clap::Parser;
+use std::path::PathBuf;
 
 use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 
@@ -111,8 +112,8 @@ impl UnxzOpts {
     }
 
     /// Files supplied on the command line
-    pub fn files(&self) -> &[String] {
-        &self.files
+    pub fn files(&self) -> Vec<PathBuf> {
+        self.files.iter().map(PathBuf::from).collect()
     }
 }
 
@@ -148,7 +149,7 @@ mod tests {
         let opts =
             UnxzOpts::try_parse_from(["unxz", "-cvk", "-T", "4", "-M", "1M", "file.xz"]).unwrap();
 
-        assert_eq!(opts.files(), ["file.xz"]);
+        assert_eq!(opts.files(), [PathBuf::from("file.xz")]);
         assert!(opts.stdout);
         assert!(opts.keep);
         assert!(opts.verbose);
@@ -171,6 +172,6 @@ mod tests {
 
         assert!(opts.stdout);
         assert_eq!(opts.memory, Some(512 * 1024));
-        assert_eq!(opts.files(), ["file.xz"]);
+        assert_eq!(opts.files(), [PathBuf::from("file.xz")]);
     }
 }

--- a/xz-cli/bin/unxz/opts.rs
+++ b/xz-cli/bin/unxz/opts.rs
@@ -22,7 +22,7 @@ use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 pub struct UnxzOpts {
     /// Files to decompress
     #[arg(value_name = "FILE")]
-    files: Vec<String>,
+    files: Vec<PathBuf>,
 
     /// Write to standard output and don't delete input files
     #[arg(short = 'c', long = "stdout", alias = "to-stdout")]
@@ -113,8 +113,8 @@ impl UnxzOpts {
     }
 
     /// Files supplied on the command line
-    pub fn files(&self) -> Vec<PathBuf> {
-        self.files.iter().map(PathBuf::from).collect()
+    pub fn files(&self) -> &[PathBuf] {
+        &self.files
     }
 }
 
@@ -125,7 +125,7 @@ mod tests {
     #[test]
     fn config_reflects_test_mode() {
         let opts = UnxzOpts {
-            files: vec!["test.xz".into()],
+            files: vec![PathBuf::from("test.xz")],
             stdout: false,
             force: true,
             keep: false,

--- a/xz-cli/bin/unxz/opts.rs
+++ b/xz-cli/bin/unxz/opts.rs
@@ -1,7 +1,8 @@
 //! Command line argument parsing for the unxz utility.
 
-use clap::Parser;
 use std::path::PathBuf;
+
+use clap::Parser;
 
 use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 

--- a/xz-cli/bin/xz/main.rs
+++ b/xz-cli/bin/xz/main.rs
@@ -3,6 +3,7 @@
 //! A modern Rust implementation of the xz compression utility, compatible with
 //! the original xz but with improved performance and user experience.
 
+use std::path::PathBuf;
 use std::process;
 
 mod opts;
@@ -53,7 +54,7 @@ fn main() {
     }
 }
 
-fn resolve_input_files(opts: &XzOpts) -> Result<Vec<String>> {
+fn resolve_input_files(opts: &XzOpts) -> Result<Vec<PathBuf>> {
     let mut files = opts.files.clone();
 
     if let Some(path) = opts.files_from_file.as_deref() {

--- a/xz-cli/bin/xz/opts.rs
+++ b/xz-cli/bin/xz/opts.rs
@@ -1,5 +1,7 @@
 //! Command line argument parsing for xz utility
 
+use std::path::PathBuf;
+
 use clap::Parser;
 
 use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
@@ -21,7 +23,7 @@ use xz_core::{config::DecodeMode, options::IntegrityCheck};
 pub struct XzOpts {
     /// Files to process
     #[arg(value_name = "FILE")]
-    pub files: Vec<String>,
+    pub files: Vec<PathBuf>,
 
     /// Force compression
     #[arg(short = 'z', long = "compress", conflicts_with_all = ["decompress", "test", "list"])]
@@ -180,7 +182,7 @@ pub struct XzOpts {
         default_missing_value = "-",
         conflicts_with = "files0_from_file"
     )]
-    pub files_from_file: Option<String>,
+    pub files_from_file: Option<PathBuf>,
 
     /// Read filenames from file (null-terminated)
     #[arg(
@@ -190,7 +192,7 @@ pub struct XzOpts {
         default_missing_value = "-",
         conflicts_with = "files_from_file"
     )]
-    pub files0_from_file: Option<String>,
+    pub files0_from_file: Option<PathBuf>,
 
     /// Machine-readable output
     #[arg(long = "robot")]
@@ -439,7 +441,7 @@ mod tests {
         assert!(opts.decompress);
         assert!(opts.stdout);
         assert_eq!(opts.memory, Some(1024 * 1024));
-        assert_eq!(opts.files, ["file.xz"]);
+        assert_eq!(opts.files, [PathBuf::from("file.xz")]);
     }
 
     #[test]

--- a/xz-cli/bin/xzcat/main.rs
+++ b/xz-cli/bin/xzcat/main.rs
@@ -17,8 +17,9 @@ const PROGRAM_NAME: &str = "xzcat";
 fn main() {
     let opts = XzCatOpts::parse();
     let config = opts.config();
+    let files = opts.files();
 
-    let report = run_cli(opts.files(), &config, PROGRAM_NAME);
+    let report = run_cli(&files, &config, PROGRAM_NAME);
     for diagnostic in &report.diagnostics {
         if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
             eprintln!("{msg}");

--- a/xz-cli/bin/xzcat/main.rs
+++ b/xz-cli/bin/xzcat/main.rs
@@ -17,9 +17,7 @@ const PROGRAM_NAME: &str = "xzcat";
 fn main() {
     let opts = XzCatOpts::parse();
     let config = opts.config();
-    let files = opts.files();
-
-    let report = run_cli(&files, &config, PROGRAM_NAME);
+    let report = run_cli(opts.files(), &config, PROGRAM_NAME);
     for diagnostic in &report.diagnostics {
         if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
             eprintln!("{msg}");

--- a/xz-cli/bin/xzcat/opts.rs
+++ b/xz-cli/bin/xzcat/opts.rs
@@ -1,6 +1,7 @@
 //! Command line argument parsing for the xzcat utility.
 
 use clap::Parser;
+use std::path::PathBuf;
 
 use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 
@@ -84,8 +85,8 @@ impl XzCatOpts {
     }
 
     /// Files supplied on the command line
-    pub fn files(&self) -> &[String] {
-        &self.files
+    pub fn files(&self) -> Vec<PathBuf> {
+        self.files.iter().map(PathBuf::from).collect()
     }
 }
 
@@ -118,7 +119,7 @@ mod tests {
         let opts = XzCatOpts::try_parse_from(["xzcat", "-v", "-T", "2", "-M", "512K", "input.xz"])
             .unwrap();
 
-        assert_eq!(opts.files(), ["input.xz"]);
+        assert_eq!(opts.files(), [PathBuf::from("input.xz")]);
         assert!(opts.verbose);
         assert_eq!(opts.threads, Some(2));
         assert_eq!(opts.memory, Some(512 * 1024));
@@ -127,7 +128,7 @@ mod tests {
     #[test]
     fn parse_single_stream_flag() {
         let opts = XzCatOpts::try_parse_from(["xzcat", "--single-stream", "input.xz"]).unwrap();
-        assert_eq!(opts.files(), ["input.xz"]);
+        assert_eq!(opts.files(), [PathBuf::from("input.xz")]);
         assert!(opts.single_stream);
     }
 
@@ -138,7 +139,7 @@ mod tests {
             Err(e) => panic!("failed to parse aliases: {e}"),
         };
 
-        assert_eq!(opts.files(), ["input.xz"]);
+        assert_eq!(opts.files(), [PathBuf::from("input.xz")]);
         assert_eq!(opts.memory, Some(1024 * 1024));
     }
 }

--- a/xz-cli/bin/xzcat/opts.rs
+++ b/xz-cli/bin/xzcat/opts.rs
@@ -21,7 +21,7 @@ use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 pub struct XzCatOpts {
     /// Files to decompress
     #[arg(value_name = "FILE")]
-    files: Vec<String>,
+    files: Vec<PathBuf>,
 
     /// Verbose mode
     #[arg(short = 'v', long = "verbose", conflicts_with = "quiet")]
@@ -86,8 +86,8 @@ impl XzCatOpts {
     }
 
     /// Files supplied on the command line
-    pub fn files(&self) -> Vec<PathBuf> {
-        self.files.iter().map(PathBuf::from).collect()
+    pub fn files(&self) -> &[PathBuf] {
+        &self.files
     }
 }
 
@@ -98,7 +98,7 @@ mod tests {
     #[test]
     fn config_sets_cat_mode_and_stdout() {
         let opts = XzCatOpts {
-            files: vec!["input.xz".into()],
+            files: vec![PathBuf::from("input.xz")],
             verbose: true,
             quiet: 0,
             threads: Some(4),

--- a/xz-cli/bin/xzcat/opts.rs
+++ b/xz-cli/bin/xzcat/opts.rs
@@ -1,7 +1,8 @@
 //! Command line argument parsing for the xzcat utility.
 
-use clap::Parser;
 use std::path::PathBuf;
+
+use clap::Parser;
 
 use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 

--- a/xz-cli/bin/xzcmp/main.rs
+++ b/xz-cli/bin/xzcmp/main.rs
@@ -95,27 +95,22 @@ fn print_version() {
 /// If the input looks like a supported compressed file, it is decompressed into a temporary
 /// file and the temporary file path is returned. Otherwise the original path is returned.
 fn materialize_for_cmp(
-    path: &OsStr,
+    path: &Path,
     config: &CliConfig,
     temps: &mut Vec<NamedTempFile>,
 ) -> Result<PathBuf, String> {
-    if path == OsStr::new("-") {
+    if path == Path::new("-") {
         // Supporting '-' is best-effort: allow it only for one side, and pass it to cmp.
         // Decompression from stdin is supported by the decompressor, but cmp consumes stdin
         // too; mixing both reliably is tricky, so we don't attempt it here.
         return Ok(PathBuf::from("-"));
     }
 
-    let p = Path::new(path);
-    if !has_compression_extension(p) {
-        return Ok(p.to_path_buf());
+    if !has_compression_extension(path) {
+        return Ok(path.to_path_buf());
     }
 
-    let mut input = open_input(
-        p.to_str()
-            .ok_or_else(|| "Non-UTF8 paths are not supported".to_string())?,
-    )
-    .map_err(|e| e.to_string())?;
+    let mut input = open_input(path).map_err(|e| e.to_string())?;
 
     let tmp = NamedTempFile::new().map_err(|e| e.to_string())?;
     {

--- a/xz-cli/bin/xzcmp/opts.rs
+++ b/xz-cli/bin/xzcmp/opts.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use xz_cli::has_compression_extension;
 
@@ -14,7 +14,7 @@ pub struct ParsedArgs {
     /// Options forwarded to the underlying `cmp` invocation.
     pub cmp_args: Vec<OsString>,
     /// FILE1 [FILE2] operands as provided by the user.
-    pub operands: Vec<OsString>,
+    pub operands: Vec<PathBuf>,
     /// Whether `--help` (or `--h*`) was requested.
     pub show_help: bool,
     /// Whether `--version` (or `--v*`) was requested.
@@ -29,7 +29,7 @@ pub fn parse_args(args: &[OsString]) -> ParsedArgs {
     let cmp_program = env::var_os("CMP").unwrap_or_else(|| OsString::from("cmp"));
 
     let mut cmp_args: Vec<OsString> = Vec::new();
-    let mut operands: Vec<OsString> = Vec::new();
+    let mut operands: Vec<PathBuf> = Vec::new();
     let mut show_help = false;
     let mut show_version = false;
 
@@ -64,7 +64,7 @@ pub fn parse_args(args: &[OsString]) -> ParsedArgs {
     }
 
     for arg in it {
-        operands.push(arg);
+        operands.push(PathBuf::from(arg));
     }
 
     ParsedArgs {
@@ -80,7 +80,7 @@ pub fn parse_args(args: &[OsString]) -> ParsedArgs {
 ///
 /// If only a single operand is provided, the second operand is inferred by stripping
 /// a supported compression suffix from `file1` (e.g. `foo.xz -> foo`).
-pub fn resolve_operands(operands: &[OsString]) -> Result<(OsString, OsString), String> {
+pub fn resolve_operands(operands: &[PathBuf]) -> Result<(PathBuf, PathBuf), String> {
     match operands.len() {
         1 => {
             let file1 = operands[0].clone();
@@ -97,27 +97,29 @@ pub fn resolve_operands(operands: &[OsString]) -> Result<(OsString, OsString), S
 /// This follows upstream `xzcmp` behavior:
 /// - `.xz`/`.lzma` suffix is stripped (case-insensitive).
 /// - `.txz`/`.tlz` is mapped to `.tar` (case-insensitive).
-fn infer_second_operand(file1: &OsStr) -> Result<OsString, String> {
-    let s = file1.to_string_lossy();
+fn infer_second_operand(file1: &Path) -> Result<PathBuf, String> {
+    let display = file1.display().to_string();
+    let file1_text = file1.as_os_str().to_string_lossy();
 
-    if ends_with_ignore_ascii_case(&s, ".txz") || ends_with_ignore_ascii_case(&s, ".tlz") {
+    if ends_with_ignore_ascii_case(&file1_text, ".txz")
+        || ends_with_ignore_ascii_case(&file1_text, ".tlz")
+    {
         // Map `.t{x,l}z` -> `.tar` like upstream `xzcmp`.
         //
         // Example: `foo.txz` -> `foo.tar`
-        let replaced = s[..s.len().saturating_sub(2)].to_string() + "ar";
-        return Ok(OsString::from(replaced));
+        let replaced = file1_text[..file1_text.len().saturating_sub(2)].to_string() + "ar";
+        return Ok(PathBuf::from(replaced));
     }
 
-    let path = Path::new(file1);
-    if !has_compression_extension(path) {
-        return Err(format!("{s}: Unknown compressed file name suffix"));
+    if !has_compression_extension(file1) {
+        return Err(format!("{display}: Unknown compressed file name suffix"));
     }
 
-    let stem = path
+    let stem = file1
         .file_stem()
-        .ok_or_else(|| format!("{s}: Unknown compressed file name suffix"))?;
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    Ok(parent.join(stem).into_os_string())
+        .ok_or_else(|| format!("{display}: Unknown compressed file name suffix"))?;
+    let parent = file1.parent().unwrap_or_else(|| Path::new("."));
+    Ok(parent.join(stem))
 }
 
 /// Returns `true` if `haystack` ends with `needle`, comparing ASCII case-insensitively.
@@ -139,7 +141,7 @@ mod tests {
         let parsed = parse_args(&args);
 
         assert!(parsed.cmp_args.is_empty());
-        assert!(parsed.operands == vec![OsString::from("-"), OsString::from("file.txt")]);
+        assert!(parsed.operands == vec![PathBuf::from("-"), PathBuf::from("file.txt")]);
     }
 
     /// Options must be forwarded to `cmp` until the first operand or `--`.
@@ -154,26 +156,26 @@ mod tests {
         let parsed = parse_args(&args);
 
         assert!(parsed.cmp_args == vec![OsString::from("-s")]);
-        assert!(parsed.operands == vec![OsString::from("a"), OsString::from("b")]);
+        assert!(parsed.operands == vec![PathBuf::from("a"), PathBuf::from("b")]);
     }
 
     /// `.xz` suffix should be stripped when inferring the second operand.
     #[test]
     fn infer_second_operand_strips_xz_extension() {
-        let out = match infer_second_operand(OsStr::new("foo.txt.xz")) {
+        let out = match infer_second_operand(Path::new("foo.txt.xz")) {
             Ok(v) => v,
             Err(err) => panic!("infer_second_operand failed: {err}"),
         };
-        assert!(out == OsStr::new("foo.txt"));
+        assert_eq!(out, PathBuf::from("foo.txt"));
     }
 
     /// `.txz` should map to `.tar` like upstream `xzcmp`.
     #[test]
     fn infer_second_operand_maps_txz_to_tar() {
-        let out = match infer_second_operand(OsStr::new("foo.txz")) {
+        let out = match infer_second_operand(Path::new("foo.txz")) {
             Ok(v) => v,
             Err(err) => panic!("infer_second_operand failed: {err}"),
         };
-        assert!(out == OsStr::new("foo.tar"));
+        assert_eq!(out, PathBuf::from("foo.tar"));
     }
 }

--- a/xz-cli/bin/xzdec/main.rs
+++ b/xz-cli/bin/xzdec/main.rs
@@ -16,8 +16,9 @@ const PROGRAM_NAME: &str = "xzdec";
 fn main() {
     let opts = XzDecOpts::parse();
     let config = opts.config();
+    let files = opts.files();
 
-    let report = run_cli(opts.files(), &config, PROGRAM_NAME);
+    let report = run_cli(&files, &config, PROGRAM_NAME);
     for diagnostic in &report.diagnostics {
         if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
             eprintln!("{msg}");

--- a/xz-cli/bin/xzdec/main.rs
+++ b/xz-cli/bin/xzdec/main.rs
@@ -16,9 +16,7 @@ const PROGRAM_NAME: &str = "xzdec";
 fn main() {
     let opts = XzDecOpts::parse();
     let config = opts.config();
-    let files = opts.files();
-
-    let report = run_cli(&files, &config, PROGRAM_NAME);
+    let report = run_cli(opts.files(), &config, PROGRAM_NAME);
     for diagnostic in &report.diagnostics {
         if let Some(msg) = format_diagnostic_for_stderr(config.quiet, diagnostic) {
             eprintln!("{msg}");

--- a/xz-cli/bin/xzdec/opts.rs
+++ b/xz-cli/bin/xzdec/opts.rs
@@ -1,6 +1,7 @@
 //! Command line argument parsing for the xzdec utility.
 
 use clap::Parser;
+use std::path::PathBuf;
 
 use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 
@@ -92,8 +93,8 @@ impl XzDecOpts {
     }
 
     /// Files supplied on the command line
-    pub fn files(&self) -> &[String] {
-        &self.files
+    pub fn files(&self) -> Vec<PathBuf> {
+        self.files.iter().map(PathBuf::from).collect()
     }
 
     /// Check if quiet mode is enabled (suppress errors when -q specified twice)
@@ -133,7 +134,7 @@ mod tests {
     fn parse_from_args_reads_memory_limit() {
         let opts = XzDecOpts::try_parse_from(["xzdec", "-M", "512K", "input.xz"]).unwrap();
 
-        assert_eq!(opts.files(), ["input.xz"]);
+        assert_eq!(opts.files(), [PathBuf::from("input.xz")]);
         assert_eq!(opts.memory, Some(512 * 1024));
         assert!(!opts.is_quiet());
     }
@@ -154,7 +155,7 @@ mod tests {
         let opts =
             XzDecOpts::try_parse_from(["xzdec", "-d", "-k", "-c", "-Q", "input.xz"]).unwrap();
 
-        assert_eq!(opts.files(), ["input.xz"]);
+        assert_eq!(opts.files(), [PathBuf::from("input.xz")]);
         // These options should be parsed but ignored in behavior
         assert!(opts.decompress);
         assert!(opts.keep);
@@ -176,7 +177,7 @@ mod tests {
             Err(e) => panic!("failed to parse aliases: {e}"),
         };
 
-        assert_eq!(opts.files(), ["input.xz"]);
+        assert_eq!(opts.files(), [PathBuf::from("input.xz")]);
         assert!(opts.decompress);
         assert!(opts.stdout);
         assert_eq!(opts.memory, Some(512 * 1024));

--- a/xz-cli/bin/xzdec/opts.rs
+++ b/xz-cli/bin/xzdec/opts.rs
@@ -24,7 +24,7 @@ use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 pub struct XzDecOpts {
     /// Files to decompress
     #[arg(value_name = "FILE")]
-    files: Vec<String>,
+    files: Vec<PathBuf>,
 
     /// Ignored for xz(1) compatibility. xzdec supports only decompression.
     #[arg(short = 'd', long = "decompress", alias = "uncompress")]
@@ -94,8 +94,8 @@ impl XzDecOpts {
     }
 
     /// Files supplied on the command line
-    pub fn files(&self) -> Vec<PathBuf> {
-        self.files.iter().map(PathBuf::from).collect()
+    pub fn files(&self) -> &[PathBuf] {
+        &self.files
     }
 
     /// Check if quiet mode is enabled (suppress errors when -q specified twice)
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn config_sets_cat_mode_and_stdout() {
         let opts = XzDecOpts {
-            files: vec!["input.xz".into()],
+            files: vec![PathBuf::from("input.xz")],
             decompress: false,
             keep: false,
             stdout: false,

--- a/xz-cli/bin/xzdec/opts.rs
+++ b/xz-cli/bin/xzdec/opts.rs
@@ -1,7 +1,8 @@
 //! Command line argument parsing for the xzdec utility.
 
-use clap::Parser;
 use std::path::PathBuf;
+
+use clap::Parser;
 
 use xz_cli::{parse_memory_limit, CliConfig, OperationMode};
 

--- a/xz-cli/bin/xzdiff/main.rs
+++ b/xz-cli/bin/xzdiff/main.rs
@@ -94,27 +94,22 @@ fn print_version() {
 /// If the input looks like a supported compressed file, it is decompressed into a temporary
 /// file and the temporary file path is returned. Otherwise the original path is returned.
 fn materialize_for_diff(
-    path: &OsStr,
+    path: &Path,
     config: &CliConfig,
     temps: &mut Vec<NamedTempFile>,
 ) -> Result<PathBuf, String> {
-    if path == OsStr::new("-") {
+    if path == Path::new("-") {
         // Supporting '-' is best-effort: allow it only for one side, and pass it to diff.
         // Decompression from stdin is supported by the decompressor, but diff consumes stdin
         // too; mixing both reliably is tricky, so we don't attempt it here.
         return Ok(PathBuf::from("-"));
     }
 
-    let p = Path::new(path);
-    if !has_compression_extension(p) {
-        return Ok(p.to_path_buf());
+    if !has_compression_extension(path) {
+        return Ok(path.to_path_buf());
     }
 
-    let mut input = open_input(
-        p.to_str()
-            .ok_or_else(|| "Non-UTF8 paths are not supported".to_string())?,
-    )
-    .map_err(|e| e.to_string())?;
+    let mut input = open_input(path).map_err(|e| e.to_string())?;
 
     let tmp = NamedTempFile::new().map_err(|e| e.to_string())?;
     {

--- a/xz-cli/bin/xzdiff/opts.rs
+++ b/xz-cli/bin/xzdiff/opts.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use xz_cli::has_compression_extension;
 
@@ -14,7 +14,7 @@ pub struct ParsedArgs {
     /// Options forwarded to the underlying `diff` invocation.
     pub diff_args: Vec<OsString>,
     /// FILE1 [FILE2] operands as provided by the user.
-    pub operands: Vec<OsString>,
+    pub operands: Vec<PathBuf>,
     /// Whether `--help` (or `--h*`) was requested.
     pub show_help: bool,
     /// Whether `--version` (or `--v*`) was requested.
@@ -29,7 +29,7 @@ pub fn parse_args(args: &[OsString]) -> ParsedArgs {
     let diff_program = env::var_os("DIFF").unwrap_or_else(|| OsString::from("diff"));
 
     let mut diff_args: Vec<OsString> = Vec::new();
-    let mut operands: Vec<OsString> = Vec::new();
+    let mut operands: Vec<PathBuf> = Vec::new();
     let mut show_help = false;
     let mut show_version = false;
 
@@ -64,7 +64,7 @@ pub fn parse_args(args: &[OsString]) -> ParsedArgs {
     }
 
     for arg in it {
-        operands.push(arg);
+        operands.push(PathBuf::from(arg));
     }
 
     ParsedArgs {
@@ -80,7 +80,7 @@ pub fn parse_args(args: &[OsString]) -> ParsedArgs {
 ///
 /// If only a single operand is provided, the second operand is inferred by stripping
 /// a supported compression suffix from `file1` (e.g. `foo.xz -> foo`).
-pub fn resolve_operands(operands: &[OsString]) -> Result<(OsString, OsString), String> {
+pub fn resolve_operands(operands: &[PathBuf]) -> Result<(PathBuf, PathBuf), String> {
     match operands.len() {
         1 => {
             let file1 = operands[0].clone();
@@ -97,27 +97,29 @@ pub fn resolve_operands(operands: &[OsString]) -> Result<(OsString, OsString), S
 /// This follows upstream `xzdiff` behavior:
 /// - `.xz`/`.lzma` suffix is stripped (case-insensitive).
 /// - `.txz`/`.tlz` is mapped to `.tar` (case-insensitive).
-fn infer_second_operand(file1: &OsStr) -> Result<OsString, String> {
-    let s = file1.to_string_lossy();
+fn infer_second_operand(file1: &Path) -> Result<PathBuf, String> {
+    let display = file1.display().to_string();
+    let file1_text = file1.as_os_str().to_string_lossy();
 
-    if ends_with_ignore_ascii_case(&s, ".txz") || ends_with_ignore_ascii_case(&s, ".tlz") {
+    if ends_with_ignore_ascii_case(&file1_text, ".txz")
+        || ends_with_ignore_ascii_case(&file1_text, ".tlz")
+    {
         // Map `.t{x,l}z` -> `.tar` like upstream `xzdiff`.
         //
         // Example: `foo.txz` -> `foo.tar`
-        let replaced = s[..s.len().saturating_sub(2)].to_string() + "ar";
-        return Ok(OsString::from(replaced));
+        let replaced = file1_text[..file1_text.len().saturating_sub(2)].to_string() + "ar";
+        return Ok(PathBuf::from(replaced));
     }
 
-    let path = Path::new(file1);
-    if !has_compression_extension(path) {
-        return Err(format!("{s}: Unknown compressed file name suffix"));
+    if !has_compression_extension(file1) {
+        return Err(format!("{display}: Unknown compressed file name suffix"));
     }
 
-    let stem = path
+    let stem = file1
         .file_stem()
-        .ok_or_else(|| format!("{s}: Unknown compressed file name suffix"))?;
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    Ok(parent.join(stem).into_os_string())
+        .ok_or_else(|| format!("{display}: Unknown compressed file name suffix"))?;
+    let parent = file1.parent().unwrap_or_else(|| Path::new("."));
+    Ok(parent.join(stem))
 }
 
 /// Returns `true` if `haystack` ends with `needle`, comparing ASCII case-insensitively.
@@ -139,7 +141,7 @@ mod tests {
         let parsed = parse_args(&args);
 
         assert!(parsed.diff_args.is_empty());
-        assert!(parsed.operands == vec![OsString::from("-"), OsString::from("file.txt")]);
+        assert!(parsed.operands == vec![PathBuf::from("-"), PathBuf::from("file.txt")]);
     }
 
     /// Options must be forwarded to `diff` until the first operand or `--`.
@@ -154,26 +156,26 @@ mod tests {
         let parsed = parse_args(&args);
 
         assert!(parsed.diff_args == vec![OsString::from("-u")]);
-        assert!(parsed.operands == vec![OsString::from("a"), OsString::from("b")]);
+        assert!(parsed.operands == vec![PathBuf::from("a"), PathBuf::from("b")]);
     }
 
     /// `.xz` suffix should be stripped when inferring the second operand.
     #[test]
     fn infer_second_operand_strips_xz_extension() {
-        let out = match infer_second_operand(OsStr::new("foo.txt.xz")) {
+        let out = match infer_second_operand(Path::new("foo.txt.xz")) {
             Ok(v) => v,
             Err(err) => panic!("infer_second_operand failed: {err}"),
         };
-        assert!(out == OsStr::new("foo.txt"));
+        assert_eq!(out, PathBuf::from("foo.txt"));
     }
 
     /// `.txz` should map to `.tar` like upstream `xzdiff`.
     #[test]
     fn infer_second_operand_maps_txz_to_tar() {
-        let out = match infer_second_operand(OsStr::new("foo.txz")) {
+        let out = match infer_second_operand(Path::new("foo.txz")) {
             Ok(v) => v,
             Err(err) => panic!("infer_second_operand failed: {err}"),
         };
-        assert!(out == OsStr::new("foo.tar"));
+        assert_eq!(out, PathBuf::from("foo.tar"));
     }
 }

--- a/xz-cli/bin/xzgrep/main.rs
+++ b/xz-cli/bin/xzgrep/main.rs
@@ -57,13 +57,13 @@ fn run() -> Result<i32, String> {
     }
 
     let files = if parsed.files.is_empty() {
-        vec![OsString::from("-")]
+        vec![PathBuf::from("-")]
     } else {
         parsed.files.clone()
     };
 
     // stdin cannot be meaningfully consumed more than once.
-    let stdin_count = files.iter().filter(|f| *f == OsStr::new("-")).count();
+    let stdin_count = files.iter().filter(|file| *file == Path::new("-")).count();
     if stdin_count > 0 && files.len() > 1 {
         return Err("'-' can only be used as the sole input".to_string());
     }
@@ -100,7 +100,6 @@ fn run() -> Result<i32, String> {
                 &parsed.grep_args,
                 need_filename_prefix,
                 &path,
-                file,
                 &caps,
             )?,
         };
@@ -192,16 +191,15 @@ enum InputKind {
 }
 
 /// Classify an input argument as stdin, plain file, or compressed file.
-fn classify_input(file: &OsStr) -> InputKind {
-    if file == OsStr::new("-") {
+fn classify_input(file: &Path) -> InputKind {
+    if file == Path::new("-") {
         return InputKind::Stdin;
     }
 
-    let p = Path::new(file);
-    if has_compression_extension(p) {
-        InputKind::Compressed(p.to_path_buf())
+    if has_compression_extension(file) {
+        InputKind::Compressed(file.to_path_buf())
     } else {
-        InputKind::Plain(p.to_path_buf())
+        InputKind::Plain(file.to_path_buf())
     }
 }
 
@@ -257,14 +255,9 @@ fn run_grep_on_compressed_file(
     grep_args: &[OsString],
     need_filename_prefix: bool,
     path: &Path,
-    original_label: &OsStr,
     caps: &GrepCaps,
 ) -> Result<i32, String> {
-    let mut input = open_input(
-        path.to_str()
-            .ok_or_else(|| "Non-UTF8 paths are not supported".to_string())?,
-    )
-    .map_err(|e| e.to_string())?;
+    let mut input = open_input(path).map_err(|err| err.to_string())?;
 
     let mut cmd = Command::new(grep_program);
     cmd.args(grep_base_args);
@@ -273,9 +266,9 @@ fn run_grep_on_compressed_file(
     if need_filename_prefix {
         cmd.arg("-H");
     }
-    if caps.supports_label && original_label != OsStr::new("-") {
+    if caps.supports_label {
         cmd.arg("--label");
-        cmd.arg(original_label);
+        cmd.arg(path);
     }
 
     // Grep reads decompressed content from stdin.

--- a/xz-cli/bin/xzgrep/main.rs
+++ b/xz-cli/bin/xzgrep/main.rs
@@ -266,6 +266,8 @@ fn run_grep_on_compressed_file(
     if need_filename_prefix {
         cmd.arg("-H");
     }
+
+    // Compressed operands are never `-`; stdin is handled by `run_grep_on_stdin`
     if caps.supports_label {
         cmd.arg("--label");
         cmd.arg(path);

--- a/xz-cli/bin/xzgrep/opts.rs
+++ b/xz-cli/bin/xzgrep/opts.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use xz_cli::has_compression_extension;
 
@@ -19,7 +19,7 @@ pub struct ParsedArgs {
     /// Options and pattern specification forwarded to the underlying `grep` invocation.
     pub grep_args: Vec<OsString>,
     /// FILE operands as provided by the user (may be empty, meaning stdin).
-    pub files: Vec<OsString>,
+    pub files: Vec<PathBuf>,
     /// Whether `--help` (or `--h*`) was requested.
     pub show_help: bool,
     /// Whether `--version` (or `--v*`) was requested.
@@ -45,8 +45,8 @@ pub fn parse_args(argv0: &OsStr, args: &[OsString]) -> Result<ParsedArgs, String
 
     let grep_program = env::var_os("GREP").unwrap_or_else(|| OsString::from("grep"));
 
-    let mut grep_args: Vec<OsString> = Vec::new();
-    let mut files: Vec<OsString> = Vec::new();
+    let mut grep_args = Vec::new();
+    let mut files = Vec::new();
     let mut show_help = false;
     let mut show_version = false;
     let mut no_filename = false;
@@ -79,7 +79,7 @@ pub fn parse_args(argv0: &OsStr, args: &[OsString]) -> Result<ParsedArgs, String
                     grep_args.push(op);
                     consumed_bare_pattern = true;
                 } else {
-                    files.push(op);
+                    files.push(PathBuf::from(op));
                 }
             }
             break;
@@ -87,7 +87,7 @@ pub fn parse_args(argv0: &OsStr, args: &[OsString]) -> Result<ParsedArgs, String
 
         // Once the (bare) PATTERN has been consumed, all remaining args are FILE operands.
         if consumed_bare_pattern || have_pat {
-            files.push(arg);
+            files.push(PathBuf::from(arg));
             continue;
         }
 
@@ -138,7 +138,7 @@ pub fn parse_args(argv0: &OsStr, args: &[OsString]) -> Result<ParsedArgs, String
         if it.peek().is_none()
             && (has_compression_extension(Path::new(&arg)) || looks_like_path_operand(&arg))
         {
-            files.push(arg);
+            files.push(PathBuf::from(arg));
             continue;
         }
         grep_args.push(OsString::from("-e"));
@@ -230,7 +230,7 @@ mod tests {
             parsed.grep_args,
             [OsString::from("-e"), OsString::from("pat")]
         );
-        assert_eq!(parsed.files, [OsString::from("f")]);
+        assert_eq!(parsed.files, [PathBuf::from("f")]);
     }
 
     /// Bare PATTERN must be wrapped with `-e`.
@@ -245,7 +245,7 @@ mod tests {
             parsed.grep_args,
             [OsString::from("-e"), OsString::from("hello")]
         );
-        assert_eq!(parsed.files, [OsString::from("file.xz")]);
+        assert_eq!(parsed.files, [PathBuf::from("file.xz")]);
     }
 
     /// `-e` should mark pattern as already provided.
@@ -269,7 +269,7 @@ mod tests {
                 OsString::from("hi")
             ]
         );
-        assert_eq!(parsed.files, [OsString::from("f.xz")]);
+        assert_eq!(parsed.files, [PathBuf::from("f.xz")]);
     }
 
     /// Missing pattern should error (unless help/version was requested).

--- a/xz-cli/bin/xzless/main.rs
+++ b/xz-cli/bin/xzless/main.rs
@@ -47,7 +47,7 @@ fn run() -> Result<i32, String> {
     }
 
     let files = if parsed.files.is_empty() {
-        vec![OsString::from("-")]
+        vec![PathBuf::from("-")]
     } else {
         parsed.files.clone()
     };
@@ -107,24 +107,15 @@ fn print_version() {
 /// a temporary file and that temporary path is returned. Otherwise, the original
 /// path is returned.
 fn prepare_input_for_pager(
-    file: &OsStr,
+    file: &Path,
     config: &CliConfig,
     temps: &mut Vec<NamedTempFile>,
 ) -> Result<PathBuf, String> {
-    if file == OsStr::new("-") {
-        return Ok(PathBuf::from("-"));
+    if !has_compression_extension(file) {
+        return Ok(file.to_path_buf());
     }
 
-    let path = Path::new(file);
-    if !has_compression_extension(path) {
-        return Ok(path.to_path_buf());
-    }
-
-    let mut input = open_input(
-        path.to_str()
-            .ok_or_else(|| "Non-UTF8 paths are not supported".to_string())?,
-    )
-    .map_err(|err| err.to_string())?;
+    let mut input = open_input(file).map_err(|err| err.to_string())?;
 
     let tmp = NamedTempFile::new().map_err(|err| err.to_string())?;
     {

--- a/xz-cli/bin/xzless/main.rs
+++ b/xz-cli/bin/xzless/main.rs
@@ -53,7 +53,7 @@ fn run() -> Result<i32, String> {
     };
 
     // stdin cannot be meaningfully consumed more than once.
-    let stdin_count = files.iter().filter(|file| *file == OsStr::new("-")).count();
+    let stdin_count = files.iter().filter(|file| *file == Path::new("-")).count();
     if stdin_count > 0 && files.len() > 1 {
         return Err("'-' can only be used as the sole input".to_string());
     }

--- a/xz-cli/bin/xzless/opts.rs
+++ b/xz-cli/bin/xzless/opts.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
 
 /// Parsed command-line arguments for `xzless`.
 #[derive(Debug, Clone)]
@@ -11,7 +12,7 @@ pub struct ParsedArgs {
     /// Options forwarded to the underlying pager invocation.
     pub pager_args: Vec<OsString>,
     /// Input file operands as provided by the user.
-    pub files: Vec<OsString>,
+    pub files: Vec<PathBuf>,
     /// Whether `--help` (or `--h*`) was requested.
     pub show_help: bool,
     /// Whether `--version` (or `--v*`) was requested.
@@ -25,8 +26,8 @@ pub struct ParsedArgs {
 pub fn parse_args(args: &[OsString]) -> ParsedArgs {
     let pager_program = env::var_os("PAGER").unwrap_or_else(|| OsString::from("less"));
 
-    let mut pager_args: Vec<OsString> = Vec::new();
-    let mut files: Vec<OsString> = Vec::new();
+    let mut pager_args = Vec::new();
+    let mut files = Vec::new();
     let mut show_help = false;
     let mut show_version = false;
 
@@ -61,7 +62,7 @@ pub fn parse_args(args: &[OsString]) -> ParsedArgs {
     }
 
     for arg in it {
-        files.push(arg);
+        files.push(PathBuf::from(arg));
     }
 
     ParsedArgs {
@@ -84,7 +85,7 @@ mod tests {
         let parsed = parse_args(&args);
 
         assert!(parsed.pager_args.is_empty());
-        assert!(parsed.files == vec![OsString::from("-"), OsString::from("file.txt")]);
+        assert!(parsed.files == vec![PathBuf::from("-"), PathBuf::from("file.txt")]);
     }
 
     /// Options must be forwarded to the pager until the first operand or `--`.
@@ -99,6 +100,6 @@ mod tests {
         let parsed = parse_args(&args);
 
         assert!(parsed.pager_args == vec![OsString::from("-F")]);
-        assert!(parsed.files == vec![OsString::from("a.xz"), OsString::from("b.txt")]);
+        assert!(parsed.files == vec![PathBuf::from("a.xz"), PathBuf::from("b.txt")]);
     }
 }

--- a/xz-cli/bin/xzmore/main.rs
+++ b/xz-cli/bin/xzmore/main.rs
@@ -47,13 +47,13 @@ fn run() -> Result<i32, String> {
     }
 
     let files = if parsed.files.is_empty() {
-        vec![OsString::from("-")]
+        vec![PathBuf::from("-")]
     } else {
         parsed.files.clone()
     };
 
     // stdin cannot be meaningfully consumed more than once.
-    let stdin_count = files.iter().filter(|file| *file == OsStr::new("-")).count();
+    let stdin_count = files.iter().filter(|file| *file == Path::new("-")).count();
     if stdin_count > 0 && files.len() > 1 {
         return Err("'-' can only be used as the sole input".to_string());
     }
@@ -107,24 +107,15 @@ fn print_version() {
 /// a temporary file and that temporary path is returned. Otherwise, the original
 /// path is returned.
 fn prepare_input_for_pager(
-    file: &OsStr,
+    file: &Path,
     config: &CliConfig,
     temps: &mut Vec<NamedTempFile>,
 ) -> Result<PathBuf, String> {
-    if file == OsStr::new("-") {
-        return Ok(PathBuf::from("-"));
+    if !has_compression_extension(file) {
+        return Ok(file.to_path_buf());
     }
 
-    let path = Path::new(file);
-    if !has_compression_extension(path) {
-        return Ok(path.to_path_buf());
-    }
-
-    let mut input = open_input(
-        path.to_str()
-            .ok_or_else(|| "Non-UTF8 paths are not supported".to_string())?,
-    )
-    .map_err(|err| err.to_string())?;
+    let mut input = open_input(file).map_err(|err| err.to_string())?;
 
     let tmp = NamedTempFile::new().map_err(|err| err.to_string())?;
     {

--- a/xz-cli/bin/xzmore/opts.rs
+++ b/xz-cli/bin/xzmore/opts.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
 
 /// Parsed command-line arguments for `xzmore`.
 #[derive(Debug, Clone)]
@@ -11,7 +12,7 @@ pub struct ParsedArgs {
     /// Options forwarded to the underlying pager invocation.
     pub pager_args: Vec<OsString>,
     /// Input file operands as provided by the user.
-    pub files: Vec<OsString>,
+    pub files: Vec<PathBuf>,
     /// Whether `--help` (or `--h*`) was requested.
     pub show_help: bool,
     /// Whether `--version` (or `--v*`) was requested.
@@ -26,7 +27,7 @@ pub fn parse_args(args: &[OsString]) -> ParsedArgs {
     let pager_program = env::var_os("PAGER").unwrap_or_else(|| OsString::from("more"));
 
     let mut pager_args: Vec<OsString> = Vec::new();
-    let mut files: Vec<OsString> = Vec::new();
+    let mut files: Vec<PathBuf> = Vec::new();
     let mut show_help = false;
     let mut show_version = false;
 
@@ -61,7 +62,7 @@ pub fn parse_args(args: &[OsString]) -> ParsedArgs {
     }
 
     for arg in it {
-        files.push(arg);
+        files.push(PathBuf::from(arg));
     }
 
     ParsedArgs {
@@ -84,7 +85,7 @@ mod tests {
         let parsed = parse_args(&args);
 
         assert!(parsed.pager_args.is_empty());
-        assert!(parsed.files == vec![OsString::from("-"), OsString::from("file.txt")]);
+        assert!(parsed.files == vec![PathBuf::from("-"), PathBuf::from("file.txt")]);
     }
 
     /// Options must be forwarded to the pager until the first operand or `--`.
@@ -99,6 +100,6 @@ mod tests {
         let parsed = parse_args(&args);
 
         assert!(parsed.pager_args == vec![OsString::from("-F")]);
-        assert!(parsed.files == vec![OsString::from("a.xz"), OsString::from("b.txt")]);
+        assert!(parsed.files == vec![PathBuf::from("a.xz"), PathBuf::from("b.txt")]);
     }
 }

--- a/xz-cli/error.rs
+++ b/xz-cli/error.rs
@@ -1,7 +1,7 @@
 //! Error types for XZ CLI operations.
 
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
@@ -108,7 +108,7 @@ pub struct Report {
 
 impl Report {
     /// Records a diagnostic and updates aggregated status.
-    pub fn record(&mut self, cause: DiagnosticCause, program: &str, file: Option<&str>) {
+    pub fn record(&mut self, cause: DiagnosticCause, program: &str, file: Option<&Path>) {
         self.status.observe_cli_error(&cause);
         self.diagnostics.push(Diagnostic::new(cause, program, file));
     }
@@ -123,7 +123,7 @@ pub struct Diagnostic {
     /// Program name to prefix in error output (e.g. "xz", "unxz").
     pub program: String,
     /// Input file path, or `None` for stdin.
-    pub file: Option<String>,
+    pub file: Option<PathBuf>,
     /// Underlying diagnostic cause produced by processing.
     pub cause: DiagnosticCause,
 }
@@ -141,10 +141,10 @@ impl Diagnostic {
     /// # Returns
     ///
     /// Returns a new [`Diagnostic`] instance with the provided context.
-    pub fn new(cause: DiagnosticCause, program: &str, file: Option<&str>) -> Self {
+    pub fn new(cause: DiagnosticCause, program: &str, file: Option<&Path>) -> Self {
         Self {
             program: program.to_string(),
-            file: file.map(String::from),
+            file: file.map(PathBuf::from),
             cause,
         }
     }
@@ -153,7 +153,7 @@ impl Diagnostic {
 impl std::fmt::Display for Diagnostic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.file.as_deref() {
-            Some(file) => write!(f, "{}: {}: {}", self.program, file, self.cause),
+            Some(file) => write!(f, "{}: {}: {}", self.program, file.display(), self.cause),
             None => write!(f, "{}: (stdin): {}", self.program, self.cause),
         }
     }

--- a/xz-cli/format/list.rs
+++ b/xz-cli/format/list.rs
@@ -1,6 +1,7 @@
 //! Formatting helpers for `xz -l` / `xz -l -v`.
 
 use std::io;
+use std::path::Path;
 
 use crate::error::{DiagnosticCause, Error, IoErrorNoCode, Result};
 use crate::utils::{bytes, math};
@@ -155,7 +156,7 @@ pub(crate) fn write_list_header_if_needed(ctx: ListOutputContext) -> Result<()> 
 /// # Returns
 ///
 /// Returns `Ok(())` on success, or an error if writing to stdout fails.
-pub(crate) fn write_list_row(summary: ListSummary, input_path: &str) -> Result<()> {
+pub(crate) fn write_list_row(summary: ListSummary, input_path: &Path) -> Result<()> {
     use std::io::Write;
 
     let ratio = math::ratio_fraction(summary.compressed, summary.uncompressed);
@@ -171,7 +172,7 @@ pub(crate) fn write_list_row(summary: ListSummary, input_path: &str) -> Result<(
         bytes::format_list_size(summary.uncompressed),
         ratio,
         check,
-        input_path
+        input_path.display()
     )
     .map_err(|source| {
         DiagnosticCause::from(Error::WriteOutput {
@@ -199,7 +200,7 @@ pub(crate) fn write_list_row(summary: ListSummary, input_path: &str) -> Result<(
 /// Returns `Ok(())` on success, or an error if writing to stdout fails.
 #[allow(clippy::too_many_lines)]
 pub(crate) fn write_verbose_report(
-    input_path: &str,
+    input_path: &Path,
     ctx: ListOutputContext,
     summary: ListSummary,
     streams: &[StreamInfo],
@@ -212,7 +213,14 @@ pub(crate) fn write_verbose_report(
     let padding_total: u64 = streams.iter().map(|s| s.padding).sum();
 
     let mut out = io::stdout().lock();
-    writeln!(out, "{input_path} ({}/{})", ctx.file_index, ctx.file_count).map_err(|source| {
+    writeln!(
+        out,
+        "{} ({}/{})",
+        input_path.display(),
+        ctx.file_index,
+        ctx.file_count
+    )
+    .map_err(|source| {
         DiagnosticCause::from(Error::WriteOutput {
             source: IoErrorNoCode::new(source),
         })

--- a/xz-cli/io/mod.rs
+++ b/xz-cli/io/mod.rs
@@ -1,7 +1,7 @@
 //! File I/O operations and path manipulation for XZ CLI.
 
 use std::ffi::OsStr;
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -156,23 +156,26 @@ pub fn generate_output_filename(
 /// # Errors
 ///
 /// Returns an error if the file cannot be opened.
-pub fn open_input(path: &str) -> Result<Box<dyn io::Read>> {
-    if path.is_empty() || path == "-" {
-        Ok(Box::new(io::BufReader::with_capacity(
+pub fn open_input(path: &Path) -> Result<Box<dyn io::Read>> {
+    let path = (!path.as_os_str().is_empty() && path != Path::new("-")).then_some(path);
+
+    let Some(path) = path else {
+        return Ok(Box::new(io::BufReader::with_capacity(
             DEFAULT_BUFFER_SIZE,
             io::stdin(),
-        )))
-    } else {
-        let file = File::open(path).map_err(|source| {
-            DiagnosticCause::from(Error::OpenInput {
-                source: IoErrorNoCode::new(source),
-            })
-        })?;
-        Ok(Box::new(io::BufReader::with_capacity(
-            DEFAULT_BUFFER_SIZE,
-            file,
-        )))
-    }
+        )));
+    };
+
+    let file = File::open(path).map_err(|source| {
+        DiagnosticCause::from(Error::OpenInput {
+            source: IoErrorNoCode::new(source),
+        })
+    })?;
+
+    Ok(Box::new(io::BufReader::with_capacity(
+        DEFAULT_BUFFER_SIZE,
+        file,
+    )))
 }
 
 /// Opens an output writer for the given path or stdout.
@@ -205,18 +208,20 @@ pub fn open_output(path: Option<&Path>, config: &CliConfig) -> Result<Box<dyn io
             io::stdout(),
         )))
     } else if let Some(path) = path {
-        // Check if output file exists and we're not forcing overwrite
-        if path.exists() && !config.force {
-            return Err(DiagnosticCause::from(Error::OutputExists {
-                path: path.to_path_buf(),
-            }));
-        }
-        let file = File::create(path).map_err(|source| {
-            DiagnosticCause::from(Error::CreateOutput {
-                path: path.to_path_buf(),
-                source: IoErrorNoCode::new(source),
-            })
-        })?;
+        let file = match open_output_file_with_options(path, config.force) {
+            Ok(file) => file,
+            Err(source) if source.kind() == io::ErrorKind::AlreadyExists && !config.force => {
+                return Err(DiagnosticCause::from(Error::OutputExists {
+                    path: path.to_path_buf(),
+                }));
+            }
+            Err(source) => {
+                return Err(DiagnosticCause::from(Error::CreateOutput {
+                    path: path.to_path_buf(),
+                    source: IoErrorNoCode::new(source),
+                }));
+            }
+        };
 
         Ok(Box::new(io::BufWriter::with_capacity(
             DEFAULT_BUFFER_SIZE,
@@ -239,17 +244,38 @@ pub fn open_output(path: Option<&Path>, config: &CliConfig) -> Result<Box<dyn io
 /// # Errors
 ///
 /// Returns an error if the file exists and overwrite isn't forced, or if creation fails.
-pub(crate) fn open_output_file(path: &Path, config: &CliConfig) -> Result<File> {
-    if path.exists() && !config.force {
-        return Err(DiagnosticCause::from(Error::OutputExists {
-            path: path.to_path_buf(),
-        }));
-    }
-
-    File::create(path).map_err(|source| {
-        DiagnosticCause::from(Error::CreateOutput {
+pub fn open_output_file(path: &Path, config: &CliConfig) -> Result<File> {
+    match open_output_file_with_options(path, config.force) {
+        Ok(file) => Ok(file),
+        Err(source) if source.kind() == io::ErrorKind::AlreadyExists && !config.force => {
+            Err(DiagnosticCause::from(Error::OutputExists {
+                path: path.to_path_buf(),
+            }))
+        }
+        Err(source) => Err(DiagnosticCause::from(Error::CreateOutput {
             path: path.to_path_buf(),
             source: IoErrorNoCode::new(source),
-        })
-    })
+        })),
+    }
+}
+
+/// Opens an output file for writing, applying `--force` overwrite semantics.
+///
+/// This is a lower-level helper used when the caller needs to keep the output as a [`File`]
+/// (e.g. to implement sparse output with `Seek`).
+///
+/// # Errors
+///
+/// Returns an error if the file exists and overwrite isn't forced, or if creation fails.
+fn open_output_file_with_options(path: &Path, force: bool) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true);
+
+    if force {
+        options.create(true).truncate(true);
+    } else {
+        options.create_new(true);
+    }
+
+    options.open(path)
 }

--- a/xz-cli/io/tests.rs
+++ b/xz-cli/io/tests.rs
@@ -8,7 +8,11 @@ use std::path::PathBuf;
 
 use tempfile::TempDir;
 
+use crate::config::CliConfig;
+use crate::error::{DiagnosticCause, Error};
+
 use super::SparseFileWriter;
+use super::{open_output, open_output_file};
 
 fn temp_file(name: &str) -> io::Result<(TempDir, PathBuf)> {
     let dir = tempfile::tempdir()?;
@@ -124,4 +128,32 @@ fn sparse_writer_handles_zero_runs_split_across_writes() {
     let mut zeros = vec![1u8; 64];
     f.read_exact(&mut zeros).unwrap();
     assert!(zeros.iter().all(|&b| b == 0));
+}
+
+/// Test that open_output rejects existing file atomically without force.
+#[test]
+fn open_output_rejects_existing_file_atomically_without_force() {
+    let (_dir, path) = temp_file("existing.tmp").unwrap();
+    std::fs::write(&path, b"existing").unwrap();
+
+    let config = CliConfig::default();
+    let err = open_output(Some(&path), &config).err().unwrap();
+    assert!(matches!(
+        err,
+        DiagnosticCause::Error(Error::OutputExists { .. })
+    ));
+}
+
+/// Test that open_output_file rejects existing file atomically without force.
+#[test]
+fn open_output_file_rejects_existing_file_atomically_without_force() {
+    let (_dir, path) = temp_file("existing-file.tmp").unwrap();
+    std::fs::write(&path, b"existing").unwrap();
+
+    let config = CliConfig::default();
+    let err = open_output_file(&path, &config).err().unwrap();
+    assert!(matches!(
+        err,
+        DiagnosticCause::Error(Error::OutputExists { .. })
+    ));
 }

--- a/xz-cli/operations.rs
+++ b/xz-cli/operations.rs
@@ -2,6 +2,7 @@
 
 use std::fs::File;
 use std::io;
+use std::path::Path;
 
 use xz_core::{
     config::EncodeFormat,
@@ -624,12 +625,13 @@ pub fn decompress_file(
 /// - The file cannot be opened or read
 /// - The file is not a valid XZ file
 /// - Memory limit is exceeded during analysis
-pub fn list_file(input_path: &str, config: &CliConfig) -> Result<()> {
+pub fn list_file(input_path: &Path, config: &CliConfig) -> Result<()> {
     let ctx = ListOutputContext {
         file_index: 1,
         file_count: 1,
         print_header: !config.robot && !config.verbose,
     };
+
     let _ = list_file_with_context(input_path, config, ctx)?;
     Ok(())
 }
@@ -654,12 +656,12 @@ pub fn list_file(input_path: &str, config: &CliConfig) -> Result<()> {
 /// - The file is not a valid XZ file
 /// - Memory limit is exceeded during analysis
 /// - Writing to stdout fails (e.g., broken pipe)
-pub(crate) fn list_file_with_context(
-    input_path: &str,
+pub fn list_file_with_context(
+    input_path: &Path,
     config: &CliConfig,
     ctx: ListOutputContext,
 ) -> Result<ListSummary> {
-    if input_path.is_empty() || input_path == "-" {
+    if input_path.as_os_str().is_empty() || input_path == Path::new("-") {
         return Err(DiagnosticCause::from(Error::ListModeStdinUnsupported));
     }
 
@@ -673,7 +675,7 @@ pub(crate) fn list_file_with_context(
     let memlimit = config.memory_limit.and_then(std::num::NonZeroU64::new);
     let info = file_info::extract_file_info(&mut file, memlimit).map_err(|e| {
         DiagnosticCause::from(Error::FileInfoExtraction {
-            path: input_path.to_string(),
+            path: input_path.display().to_string(),
             message: e.to_string(),
         })
     })?;
@@ -694,7 +696,7 @@ pub(crate) fn list_file_with_context(
         writeln!(
             out,
             "{}\t{}\t{}\t{}\t{:.3}\t{}",
-            input_path,
+            input_path.display(),
             info.stream_count(),
             info.block_count(),
             info.file_size(),

--- a/xz-cli/process.rs
+++ b/xz-cli/process.rs
@@ -1,7 +1,7 @@
 //! High-level file processing and CLI orchestration.
 
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::config::{CliConfig, OperationMode};
 use crate::error::{DiagnosticCause, Error, ExitStatus, IoErrorNoCode, Report, Result};
@@ -10,6 +10,11 @@ use crate::io::{
     generate_output_filename, open_input, open_output, open_output_file, SparseFileWriter,
 };
 use crate::operations::{compress_file, decompress_file, list_file, list_file_with_context};
+
+/// Returns `true` if the input path is stdin.
+fn is_stdin_path(input_path: &Path) -> bool {
+    input_path.as_os_str().is_empty() || input_path == Path::new("-")
+}
 
 /// Removes the input file after successful processing.
 ///
@@ -28,13 +33,13 @@ use crate::operations::{compress_file, decompress_file, list_file, list_file_wit
 /// # Errors
 ///
 /// Returns an error if file removal fails.
-pub fn cleanup_input_file(input_path: &str, config: &CliConfig) -> Result<()> {
+pub fn cleanup_input_file(input_path: &Path, config: &CliConfig) -> Result<()> {
     // Never delete input file in Test mode
     if config.mode == OperationMode::Test || config.mode == OperationMode::List {
         return Ok(());
     }
 
-    let is_stdin = input_path.is_empty() || input_path == "-";
+    let is_stdin = is_stdin_path(input_path);
 
     if !config.keep && !is_stdin && !config.stdout {
         std::fs::remove_file(input_path).map_err(|source| {
@@ -44,7 +49,7 @@ pub fn cleanup_input_file(input_path: &str, config: &CliConfig) -> Result<()> {
         })?;
 
         if config.verbose {
-            eprintln!("Removed input file: {input_path}");
+            eprintln!("Removed input file: {}", input_path.display());
         }
     }
     Ok(())
@@ -87,8 +92,8 @@ pub fn cleanup_input_file(input_path: &str, config: &CliConfig) -> Result<()> {
 /// - Output file exists and `force` flag is not set
 /// - Compression/decompression operation fails
 /// - Input file removal fails (when cleanup is enabled)
-pub fn process_file(input_path: &str, config: &CliConfig) -> Result<()> {
-    let is_stdin = input_path.is_empty() || input_path == "-";
+pub fn process_file(input_path: &Path, config: &CliConfig) -> Result<()> {
+    let is_stdin = is_stdin_path(input_path);
 
     if matches!(config.format, xz_core::config::DecodeMode::Raw)
         && matches!(
@@ -108,7 +113,7 @@ pub fn process_file(input_path: &str, config: &CliConfig) -> Result<()> {
     let input_path_buf = if is_stdin {
         PathBuf::new()
     } else {
-        PathBuf::from(input_path)
+        input_path.to_path_buf()
     };
 
     let input = open_input(input_path)?;
@@ -175,9 +180,9 @@ pub fn process_file(input_path: &str, config: &CliConfig) -> Result<()> {
 
             if config.verbose || config.robot {
                 if config.robot {
-                    println!("OK {input_path}");
+                    println!("OK {}", input_path.display());
                 } else {
-                    eprintln!("Test successful: {input_path}");
+                    eprintln!("Test successful: {}", input_path.display());
                 }
             }
         }
@@ -276,7 +281,7 @@ pub fn parse_memory_limit(s: &str) -> Result<u64> {
 ///
 /// Returns `Ok(())` on success, or an error if any file operation fails.
 /// Gracefully handles `BrokenPipe` errors by returning `Ok(())`.
-fn process_list_files(files: &[String], config: &CliConfig, program: &str) -> Report {
+fn process_list_files(files: &[PathBuf], config: &CliConfig, program: &str) -> Report {
     let mut report = Report::default();
     let total = files.len();
     let mut header_printed = false;
@@ -332,7 +337,7 @@ fn process_list_files(files: &[String], config: &CliConfig, program: &str) -> Re
 /// # Returns
 ///
 /// Returns `Ok(())` if all files were processed successfully.
-fn process_files(files: &[String], config: &CliConfig, program: &str) -> Report {
+fn process_files(files: &[PathBuf], config: &CliConfig, program: &str) -> Report {
     let mut report = Report::default();
     for file in files {
         match process_file(file, config) {
@@ -368,7 +373,7 @@ fn process_files(files: &[String], config: &CliConfig, program: &str) -> Report 
 ///
 /// This function does not fail fast. It continues processing remaining files
 /// after per-file errors and aggregates the exit code like upstream `xz`.
-pub fn run_cli(files: &[String], config: &CliConfig, program: &str) -> Report {
+pub fn run_cli(files: &[PathBuf], config: &CliConfig, program: &str) -> Report {
     let mut report = Report::default();
 
     if config.mode == OperationMode::List && files.is_empty() {
@@ -382,7 +387,7 @@ pub fn run_cli(files: &[String], config: &CliConfig, program: &str) -> Report {
     }
 
     if files.is_empty() {
-        match process_file("", config) {
+        match process_file(Path::new(""), config) {
             Ok(()) => {}
             Err(err) => {
                 if !is_broken_pipe(&err) {

--- a/xz-cli/tests/test_cli/xz/edge_cases.rs
+++ b/xz-cli/tests/test_cli/xz/edge_cases.rs
@@ -7,6 +7,9 @@ use crate::add_test;
 use crate::common::{generate_random_data, BinaryType, Fixture};
 use crate::MB;
 
+#[cfg(unix)]
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
 // Test empty file handling
 add_test!(empty_file, async {
     const FILE_NAME: &str = "empty.txt";
@@ -288,6 +291,39 @@ add_test!(list_rejects_no_files_stdin, async {
         .await;
     assert!(!output.status.success());
     assert!(output.stderr.contains("not support"));
+});
+
+// Test that `xz --files0` accepts non-UTF8 paths.
+#[cfg(unix)]
+add_test!(files0_accepts_non_utf8_paths, async {
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+
+    let mut fixture = Fixture::with_file("placeholder.txt", b"placeholder");
+    fixture.remove_file("placeholder.txt");
+
+    let mut input_bytes = fixture.root_dir_path().as_os_str().as_bytes().to_vec();
+    input_bytes.push(b'/');
+    input_bytes.extend_from_slice(b"bad-\xFF-name.txt");
+    let input_path = PathBuf::from(OsString::from_vec(input_bytes.clone()));
+    std::fs::write(&input_path, b"non-utf8-path-data").unwrap();
+
+    let mut stdin = input_bytes;
+    stdin.push(0);
+
+    let output = fixture
+        .run_with_stdin_raw(BinaryType::cargo("xz"), &["--files0=-", "-k"], &stdin)
+        .await;
+    assert!(
+        output.status.success(),
+        "xz --files0 failed: {}",
+        output.stderr
+    );
+
+    let mut compressed_bytes = input_path.as_os_str().as_bytes().to_vec();
+    compressed_bytes.extend_from_slice(b".xz");
+    let compressed_path = PathBuf::from(OsString::from_vec(compressed_bytes));
+    assert!(compressed_path.exists(), "compressed file was not created");
 });
 
 // Test upstream-like exit codes and continued processing across multiple files:

--- a/xz-cli/tests/test_cli/xz/edge_cases.rs
+++ b/xz-cli/tests/test_cli/xz/edge_cases.rs
@@ -293,6 +293,41 @@ add_test!(list_rejects_no_files_stdin, async {
     assert!(output.stderr.contains("not support"));
 });
 
+// Test that `xz --files` accepts non-UTF8 paths.
+#[cfg(unix)]
+add_test!(files_accepts_non_utf8_paths, async {
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+
+    let mut fixture = Fixture::with_file("placeholder.txt", b"placeholder");
+    fixture.remove_file("placeholder.txt");
+
+    let mut input_bytes = fixture.root_dir_path().as_os_str().as_bytes().to_vec();
+    input_bytes.push(b'/');
+    input_bytes.extend_from_slice(b"bad-\xFF-name.txt");
+    let input_path = PathBuf::from(OsString::from_vec(input_bytes.clone()));
+    std::fs::write(&input_path, b"non-utf8-path-data").unwrap();
+
+    let list_path = fixture.path("files.list");
+    let mut list_content = input_bytes.clone();
+    list_content.push(b'\n');
+    std::fs::write(&list_path, &list_content).unwrap();
+
+    let output = fixture
+        .run_cargo("xz", &["--files", &list_path, "-k"])
+        .await;
+    assert!(
+        output.status.success(),
+        "xz --files failed: {}",
+        output.stderr
+    );
+
+    let mut compressed_bytes = input_path.as_os_str().as_bytes().to_vec();
+    compressed_bytes.extend_from_slice(b".xz");
+    let compressed_path = PathBuf::from(OsString::from_vec(compressed_bytes));
+    assert!(compressed_path.exists(), "compressed file was not created");
+});
+
 // Test that `xz --files0` accepts non-UTF8 paths.
 #[cfg(unix)]
 add_test!(files0_accepts_non_utf8_paths, async {

--- a/xz-cli/utils/argfiles.rs
+++ b/xz-cli/utils/argfiles.rs
@@ -4,9 +4,13 @@
 //! (either newline-delimited or NUL-delimited). This module provides the shared
 //! logic to read and parse such lists.
 
+use std::ffi::OsString;
 use std::fs::File;
 use std::io::{self, Read};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
 
 /// Delimiter used to separate file names in an argument file list.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -25,17 +29,13 @@ pub enum Delimiter {
 ///
 /// Returns an error if:
 /// - the list source cannot be read
-/// - the list contains a file name that is not valid UTF-8
-pub fn read_files(path: Option<&str>, delimiter: Delimiter) -> io::Result<Vec<String>> {
+pub fn read_files(path: Option<&Path>, delimiter: Delimiter) -> io::Result<Vec<PathBuf>> {
     let mut buf = Vec::new();
 
-    match path {
-        None | Some("-") => {
-            io::stdin().lock().read_to_end(&mut buf)?;
-        }
-        Some(path) => {
-            File::open(Path::new(path))?.read_to_end(&mut buf)?;
-        }
+    if path.is_none() || path == Some(Path::new("-")) {
+        io::stdin().lock().read_to_end(&mut buf)?;
+    } else if let Some(path) = path {
+        File::open(path)?.read_to_end(&mut buf)?;
     }
 
     match delimiter {
@@ -44,32 +44,83 @@ pub fn read_files(path: Option<&str>, delimiter: Delimiter) -> io::Result<Vec<St
     }
 }
 
-fn parse_line_delimited(buf: &[u8]) -> io::Result<Vec<String>> {
-    let s = String::from_utf8(buf.to_vec())
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-
+/// Parse a line-delimited list of file names.
+fn parse_line_delimited(buf: &[u8]) -> io::Result<Vec<PathBuf>> {
     let mut out = Vec::new();
-    for line in s.split('\n') {
-        let line = line.strip_suffix('\r').unwrap_or(line);
+    for line in buf.split(|b| *b == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
         if line.is_empty() {
             continue;
         }
-        out.push(line.to_string());
+        out.push(path_from_bytes(line)?);
     }
 
     Ok(out)
 }
 
-fn parse_nul_delimited(buf: &[u8]) -> io::Result<Vec<String>> {
+/// Parse a NUL-delimited list of file names.
+fn parse_nul_delimited(buf: &[u8]) -> io::Result<Vec<PathBuf>> {
     let mut out = Vec::new();
     for part in buf.split(|b| *b == 0) {
         if part.is_empty() {
             continue;
         }
-        let s =
-            std::str::from_utf8(part).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        out.push(s.to_string());
+        out.push(path_from_bytes(part)?);
     }
 
     Ok(out)
+}
+
+/// Convert a byte slice to a `PathBuf`.
+///
+/// # Errors
+///
+/// Returns an error if the byte slice is not valid UTF-8.
+#[cfg(unix)]
+fn path_from_bytes(bytes: &[u8]) -> io::Result<PathBuf> {
+    Ok(PathBuf::from(OsString::from_vec(bytes.to_vec())))
+}
+
+/// Convert a byte slice to a `PathBuf`.
+///
+/// # Errors
+///
+/// Returns an error if the byte slice is not valid UTF-8.
+#[cfg(not(unix))]
+fn path_from_bytes(bytes: &[u8]) -> io::Result<PathBuf> {
+    let path = String::from_utf8(bytes.to_vec())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    Ok(PathBuf::from(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    use std::os::unix::ffi::OsStrExt;
+
+    /// Test that line-delimited paths are parsed correctly.
+    #[test]
+    fn parses_line_delimited_paths_without_extra_copying_through_utf8() {
+        let parsed = parse_line_delimited(b"alpha\nbeta\r\ngamma\n").unwrap();
+        assert_eq!(
+            parsed,
+            vec![
+                PathBuf::from("alpha"),
+                PathBuf::from("beta"),
+                PathBuf::from("gamma")
+            ]
+        );
+    }
+
+    /// Test that NUL-delimited paths are parsed correctly.
+    #[cfg(unix)]
+    #[test]
+    fn parses_nul_delimited_non_utf8_paths() {
+        let parsed = parse_nul_delimited(b"valid\0bad-\xFF-name\0").unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0], PathBuf::from("valid"));
+        assert_eq!(parsed[1].as_os_str().as_bytes(), b"bad-\xFF-name");
+    }
 }

--- a/xz-cli/utils/argfiles.rs
+++ b/xz-cli/utils/argfiles.rs
@@ -71,11 +71,7 @@ fn parse_nul_delimited(buf: &[u8]) -> io::Result<Vec<PathBuf>> {
     Ok(out)
 }
 
-/// Convert a byte slice to a `PathBuf`.
-///
-/// # Errors
-///
-/// Returns an error if the byte slice is not valid UTF-8.
+/// Convert a byte slice to a `PathBuf`, preserving arbitrary OS bytes on Unix.
 #[cfg(unix)]
 fn path_from_bytes(bytes: &[u8]) -> io::Result<PathBuf> {
     Ok(PathBuf::from(OsString::from_vec(bytes.to_vec())))


### PR DESCRIPTION
1. Added path-based execution for xz, preserving non-UTF-8 filenames through --files0
2. Removed the UTF-8-only argfile parsing path
3. Replaced the non-atomic output-file existence check with OpenOptions-based creation.