### PR TITLE
Fixed CLI regressions

### DIFF
--- a/xz-cli/operations.rs
+++ b/xz-cli/operations.rs
@@ -366,7 +366,7 @@ fn emit_compress_summary(config: &CliConfig, bytes_read: u64, bytes_written: u64
 
     let ratio = ratio(bytes_written, bytes_read);
     if config.robot {
-        println!("{bytes_read} {bytes_written} {ratio:.1}");
+        eprintln!("{bytes_read} {bytes_written} {ratio:.1}");
     } else {
         eprintln!("Compressed {bytes_read} bytes to {bytes_written} bytes ({ratio:.1}% ratio)");
     }
@@ -437,7 +437,7 @@ fn emit_decompress_summary(config: &CliConfig, bytes_read: u64, bytes_written: u
 
     let ratio = ratio(bytes_written, bytes_read);
     if config.robot {
-        println!("{bytes_read} {bytes_written} {ratio:.1}");
+        eprintln!("{bytes_read} {bytes_written} {ratio:.1}");
     } else {
         eprintln!(
             "Decompressed {bytes_read} bytes to {bytes_written} bytes ({ratio:.1}% expansion)"
@@ -470,6 +470,12 @@ fn apply_threads_for_decompression(
 
     let thread_count = u32::try_from(threads)
         .map_err(|_| DiagnosticCause::from(Error::InvalidThreadCount { count: threads }))?;
+    if config.format == xz_core::config::DecodeMode::Auto {
+        // Auto-detect mode cannot use liblzma's multi-threaded decoder. Ignore the
+        // CLI thread request here so common `xz -d -T4 file.xz` style invocations
+        // keep working instead of failing up front.
+        return Ok(options);
+    }
     options = options.with_threads(xz_core::Threading::Exact(thread_count));
     Ok(options)
 }

--- a/xz-cli/operations.rs
+++ b/xz-cli/operations.rs
@@ -464,18 +464,18 @@ fn apply_threads_for_decompression(
         return Ok(options);
     };
 
-    if config.format == xz_core::config::DecodeMode::Lzma {
-        return Ok(options);
-    }
-
-    let thread_count = u32::try_from(threads)
-        .map_err(|_| DiagnosticCause::from(Error::InvalidThreadCount { count: threads }))?;
     if config.format == xz_core::config::DecodeMode::Auto {
         // Auto-detect mode cannot use liblzma's multi-threaded decoder. Ignore the
         // CLI thread request here so common `xz -d -T4 file.xz` style invocations
         // keep working instead of failing up front.
         return Ok(options);
     }
+    if config.format == xz_core::config::DecodeMode::Lzma {
+        return Ok(options);
+    }
+
+    let thread_count = u32::try_from(threads)
+        .map_err(|_| DiagnosticCause::from(Error::InvalidThreadCount { count: threads }))?;
     options = options.with_threads(xz_core::Threading::Exact(thread_count));
     Ok(options)
 }

--- a/xz-cli/process.rs
+++ b/xz-cli/process.rs
@@ -175,7 +175,7 @@ pub fn process_file(input_path: &str, config: &CliConfig) -> Result<()> {
 
             if config.verbose || config.robot {
                 if config.robot {
-                    println!("OK {input_path}");
+                    eprintln!("OK {input_path}");
                 } else {
                     eprintln!("Test successful: {input_path}");
                 }

--- a/xz-cli/tests/test_cli/unxz/cli_options.rs
+++ b/xz-cli/tests/test_cli/unxz/cli_options.rs
@@ -68,6 +68,25 @@ add_test!(stdout_long_option, async {
     assert!(output.stdout_raw == data);
 });
 
+// `unxz -T4` should still succeed with the default auto-detect format.
+add_test!(threaded_auto_decompression_does_not_fail, async {
+    const FILE_NAME: &str = "threaded_auto_decode.txt";
+    let data = generate_random_data(KB);
+    let mut fixture = Fixture::with_file(FILE_NAME, &data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let compressed_path = fixture.compressed_path(FILE_NAME);
+
+    let output = fixture.run_cargo("xz", &[&file_path]).await;
+    assert!(output.status.success());
+
+    let output = fixture
+        .run_cargo("unxz", &["-T4", "--stdout", &compressed_path])
+        .await;
+    assert!(output.status.success());
+    assert_eq!(output.stdout_raw, data);
+});
+
 // Test unxz with --keep (long form)
 add_test!(keep_long_option, async {
     const FILE_NAME: &str = "keep_long.txt";

--- a/xz-cli/tests/test_cli/xz/cli_options.rs
+++ b/xz-cli/tests/test_cli/xz/cli_options.rs
@@ -424,6 +424,85 @@ add_test!(stdout_long_option, async {
     assert!(!output.stdout.is_empty());
 });
 
+// `xz -d -T4` should still succeed with the default auto-detect format.
+add_test!(threaded_auto_decompression_does_not_fail, async {
+    const FILE_NAME: &str = "threaded_auto_decode.txt";
+    let data = generate_random_data(KB);
+    let mut fixture = Fixture::with_file(FILE_NAME, &data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let compressed_path = fixture.compressed_path(FILE_NAME);
+
+    let output = fixture.run_cargo("xz", &[&file_path]).await;
+    assert!(output.status.success());
+
+    let output = fixture
+        .run_cargo("xz", &["-d", "-T4", "-c", &compressed_path])
+        .await;
+    assert!(output.status.success());
+    assert_eq!(output.stdout_raw, data);
+});
+
+// `--robot -c` must keep compressed bytes on stdout and diagnostics on stderr.
+add_test!(robot_stdout_keeps_compressed_stream_clean, async {
+    const FILE_NAME: &str = "robot_stdout.txt";
+    let data = generate_random_data(KB);
+    let mut fixture = Fixture::with_file(FILE_NAME, &data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let output = fixture
+        .run_cargo("xz", &["--robot", "-c", &file_path])
+        .await;
+    assert!(output.status.success());
+    assert!(!output.stderr.is_empty());
+
+    let roundtrip = fixture
+        .run_with_stdin_raw(BinaryType::cargo("xz"), &["-d", "-c"], &output.stdout_raw)
+        .await;
+    assert!(roundtrip.status.success());
+    assert_eq!(roundtrip.stdout_raw, data);
+});
+
+// `xz -d --robot -c` must keep payload bytes on stdout and diagnostics on stderr.
+add_test!(robot_decompress_stdout_keeps_payload_clean, async {
+    const FILE_NAME: &str = "robot_decompress_stdout.txt";
+    let data = generate_random_data(KB);
+    let mut fixture = Fixture::with_file(FILE_NAME, &data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let compressed_path = fixture.compressed_path(FILE_NAME);
+
+    let output = fixture.run_cargo("xz", &[&file_path]).await;
+    assert!(output.status.success());
+
+    let output = fixture
+        .run_cargo("xz", &["-d", "--robot", "-c", &compressed_path])
+        .await;
+    assert!(output.status.success());
+    assert_eq!(output.stdout_raw, data);
+    assert!(!output.stderr.is_empty());
+});
+
+// `xz -t --robot` must not print status lines to stdout.
+add_test!(robot_test_mode_writes_status_to_stderr, async {
+    const FILE_NAME: &str = "robot_test_mode.txt";
+    let data = generate_random_data(KB);
+    let mut fixture = Fixture::with_file(FILE_NAME, &data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let compressed_path = fixture.compressed_path(FILE_NAME);
+
+    let output = fixture.run_cargo("xz", &[&file_path]).await;
+    assert!(output.status.success());
+
+    let output = fixture
+        .run_cargo("xz", &["-t", "--robot", &compressed_path])
+        .await;
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.contains("OK"));
+});
+
 // Test -S/--suffix option
 add_test!(custom_suffix_option, async {
     const FILE_NAME: &str = "suffix_test.txt";

--- a/xz-cli/tests/test_cli/xzcat/cli_options.rs
+++ b/xz-cli/tests/test_cli/xzcat/cli_options.rs
@@ -115,6 +115,23 @@ add_test!(different_compression_levels, async {
     }
 });
 
+// `xzcat -T4` should still decode normal `.xz` inputs in auto mode.
+add_test!(threaded_auto_decompression_does_not_fail, async {
+    const FILE_NAME: &str = "threaded_auto_decode.txt";
+    let data = generate_random_data(KB);
+    let mut fixture = Fixture::with_file(FILE_NAME, &data);
+
+    let file_path = fixture.path(FILE_NAME);
+    let compressed_path = fixture.compressed_path(FILE_NAME);
+
+    let output = fixture.run_cargo("xz", &[&file_path]).await;
+    assert!(output.status.success());
+
+    let output = fixture.run_cargo("xzcat", &["-T4", &compressed_path]).await;
+    assert!(output.status.success());
+    assert_eq!(output.stdout_raw, data);
+});
+
 // Test xzcat processes files in order
 add_test!(file_order, async {
     const FILES: [&str; 3] = ["a.txt", "b.txt", "c.txt"];


### PR DESCRIPTION
1. xz-cli so xz -d -T4 / unxz -T4 / xzcat -T4 no longer fail in default auto-detect mode
2. Moved --robot / test-status output off stdout so payload streams stay clean.